### PR TITLE
Address getting started bugs

### DIFF
--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -21,7 +21,7 @@ serialize:
 	echo ${CURDIR}
 	mkdir ${CURDIR}/_pb_output || true
 	rm ${CURDIR}/_pb_output/* || true
-	pyflyte -c sandbox.config --pkgs recipes serialize --in-container-config-path /root/sandbox.config --local-source-root ${CURDIR} --image ${FULL_IMAGE_NAME}:${VERSION} workflows -f _pb_output/
+	pyflyte -c sandbox.config --pkgs recipes.core serialize --in-container-config-path /root/sandbox.config --local-source-root ${CURDIR} --image ${FULL_IMAGE_NAME}:${VERSION} workflows -f _pb_output/
 
 .PHONY: register
 register:
@@ -34,7 +34,7 @@ fast_serialize:
 	echo ${CURDIR}
 	mkdir ${CURDIR}/_pb_output || true
 	rm ${CURDIR}/_pb_output/* || true
-	pyflyte -c sandbox.config --pkgs recipes serialize --in-container-config-path /root/sandbox.config --local-source-root ${CURDIR} --image ${FULL_IMAGE_NAME}:${VERSION} fast workflows -f _pb_output/
+	pyflyte -c sandbox.config --pkgs.core recipes.core serialize --in-container-config-path /root/sandbox.config --local-source-root ${CURDIR} --image ${FULL_IMAGE_NAME}:${VERSION} fast workflows -f _pb_output/
 
 .PHONY: fast_register
 fast_register:

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -7,7 +7,7 @@ in_container_serialize_sandbox:
 .PHONY: register_sandbox
 register_sandbox: docker_build serialize_sandbox
 	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
-	flyte-cli register-files ${INSECURE} -p ${PROJECT} -d development -v ${VERSION} -h ${FLYTE_HOST} ${CURDIR}/_pb_output/*
+	flyte-cli register-files -h ${FLYTE_HOST} ${INSECURE} -p ${PROJECT} -d development -v ${VERSION} ${CURDIR}/_pb_output/*
 
 .PHONY: serialize_sandbox
 serialize_sandbox: dev_docker_build
@@ -27,7 +27,7 @@ serialize:
 register:
 	test $(OUTPUT_DATA_PREFIX) || ( echo ">> OUTPUT_DATA_PREFIX is not set"; exit 1 )
 	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
-	flyte-cli register-files ${INSECURE} -p flytetester -d development -v ${VERSION} --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} _pb_output/*
+	flyte-cli register-files -h ${FLYTE_HOST} ${INSECURE} -p flytetester -d development -v ${VERSION} --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} _pb_output/*
 
 .PHONY: fast_serialize
 fast_serialize:
@@ -41,14 +41,13 @@ fast_register:
 	test $(OUTPUT_DATA_PREFIX) || ( echo ">> OUTPUT_DATA_PREFIX is not set"; exit 1 )
 	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
 	test $(ADDL_DISTRIBUTION_DIR) || ( echo ">> ADDL_DISTRIBUTION_DIR is not set"; exit 1 )
-	flyte-cli fast-register-files ${INSECURE} -p flytetester -d development --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} --additional-distribution-dir ${ADDL_DISTRIBUTION_DIR} _pb_output/*
+	flyte-cli fast-register-files -h ${FLYTE_HOST} ${INSECURE} -p flytetester -d development --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} --additional-distribution-dir ${ADDL_DISTRIBUTION_DIR} _pb_output/*
 
 .PHONY: fast_register_sandbox
 fast_register_sandbox: fast_serialize_sandbox
 	echo "Registering against localhost. Follow the README to use a remote Flyte installation"
-	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
 	FLYTE_AWS_ENDPOINT=http://localhost:9000/ FLYTE_AWS_ACCESS_KEY_ID=minio FLYTE_AWS_SECRET_ACCESS_KEY=miniostorage \
-		flyte-cli fast-register-files ${INSECURE} -p ${PROJECT} -d development -h localhost:30081 ${INSECURE} \
+		flyte-cli fast-register-files -h localhost:80 ${INSECURE} -p ${PROJECT} -d development ${INSECURE} \
 		--additional-distribution-dir s3://my-s3-bucket/fast/ --dest-dir /root/recipes ${CURDIR}/_pb_output/*
 
 .PHONY: in_container_fast_serialize_sandbox

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -7,7 +7,7 @@ in_container_serialize_sandbox:
 .PHONY: register_sandbox
 register_sandbox: docker_build serialize_sandbox
 	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
-	flyte-cli register-files -i -p ${PROJECT} -d development -v ${VERSION} -h ${FLYTE_HOST} ${CURDIR}/_pb_output/*
+	flyte-cli register-files ${INSECURE} -p ${PROJECT} -d development -v ${VERSION} -h ${FLYTE_HOST} ${CURDIR}/_pb_output/*
 
 .PHONY: serialize_sandbox
 serialize_sandbox: dev_docker_build
@@ -48,7 +48,7 @@ fast_register_sandbox: fast_serialize_sandbox
 	echo "Registering against localhost. Follow the README to use a remote Flyte installation"
 	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
 	FLYTE_AWS_ENDPOINT=http://localhost:9000/ FLYTE_AWS_ACCESS_KEY_ID=minio FLYTE_AWS_SECRET_ACCESS_KEY=miniostorage \
-		flyte-cli fast-register-files ${INSECURE} -p ${PROJECT} -d development -h localhost:30081 -i \
+		flyte-cli fast-register-files ${INSECURE} -p ${PROJECT} -d development -h localhost:30081 ${INSECURE} \
 		--additional-distribution-dir s3://my-s3-bucket/fast/ --dest-dir /root/recipes ${CURDIR}/_pb_output/*
 
 .PHONY: in_container_fast_serialize_sandbox

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -6,7 +6,8 @@ in_container_serialize_sandbox:
 
 .PHONY: register_sandbox
 register_sandbox: docker_build serialize_sandbox
-	flyte-cli register-files -i -p ${PROJECT} -d development -v ${VERSION} -h localhost:30081 ${CURDIR}/_pb_output/*
+	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
+	flyte-cli register-files -i -p ${PROJECT} -d development -v ${VERSION} -h ${FLYTE_HOST} ${CURDIR}/_pb_output/*
 
 .PHONY: serialize_sandbox
 serialize_sandbox: dev_docker_build
@@ -24,8 +25,8 @@ serialize:
 
 .PHONY: register
 register:
-	test $(OUTPUT_DATA_PREFIX)
-	test $(FLYTE_HOST)
+	test $(OUTPUT_DATA_PREFIX) || ( echo ">> OUTPUT_DATA_PREFIX is not set"; exit 1 )
+	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
 	flyte-cli register-files ${INSECURE} -p flytetester -d development -v ${VERSION} --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} _pb_output/*
 
 .PHONY: fast_serialize
@@ -37,11 +38,15 @@ fast_serialize:
 
 .PHONY: fast_register
 fast_register:
+	test $(OUTPUT_DATA_PREFIX) || ( echo ">> OUTPUT_DATA_PREFIX is not set"; exit 1 )
+	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
+	test $(ADDL_DISTRIBUTION_DIR) || ( echo ">> ADDL_DISTRIBUTION_DIR is not set"; exit 1 )
 	flyte-cli fast-register-files ${INSECURE} -p flytetester -d development --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} --additional-distribution-dir ${ADDL_DISTRIBUTION_DIR} _pb_output/*
 
 .PHONY: fast_register_sandbox
 fast_register_sandbox: fast_serialize_sandbox
 	echo "Registering against localhost. Follow the README to use a remote Flyte installation"
+	test $(FLYTE_HOST) || ( echo ">> FLYTE_HOST is not set"; exit 1 )
 	FLYTE_AWS_ENDPOINT=http://localhost:9000/ FLYTE_AWS_ACCESS_KEY_ID=minio FLYTE_AWS_SECRET_ACCESS_KEY=miniostorage \
 		flyte-cli fast-register-files ${INSECURE} -p ${PROJECT} -d development -h localhost:30081 -i \
 		--additional-distribution-dir s3://my-s3-bucket/fast/ --dest-dir /root/recipes ${CURDIR}/_pb_output/*

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -24,7 +24,7 @@ serialize:
 
 .PHONY: register
 register:
-	flyte-cli register-files -p flytetester -d development -v ${VERSION} --kubernetes-service-account demo --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} _pb_output/*
+	flyte-cli register-files ${INSECURE} -p flytetester -d development -v ${VERSION} --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} _pb_output/*
 
 .PHONY: fast_serialize
 fast_serialize:
@@ -35,13 +35,13 @@ fast_serialize:
 
 .PHONY: fast_register
 fast_register:
-	flyte-cli fast-register-files -p flytetester -d development --kubernetes-service-account demo --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} --additional-distribution-dir ${ADDL_DISTRIBUTION_DIR} _pb_output/*
+	flyte-cli fast-register-files ${INSECURE} -p flytetester -d development --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} --additional-distribution-dir ${ADDL_DISTRIBUTION_DIR} _pb_output/*
 
 .PHONY: fast_register_sandbox
 fast_register_sandbox: fast_serialize_sandbox
 	echo "Registering against localhost. Follow the README to use a remote Flyte installation"
 	FLYTE_AWS_ENDPOINT=http://localhost:9000/ FLYTE_AWS_ACCESS_KEY_ID=minio FLYTE_AWS_SECRET_ACCESS_KEY=miniostorage \
-		flyte-cli fast-register-files -p ${PROJECT} -d development -h localhost:30081 -i \
+		flyte-cli fast-register-files ${INSECURE} -p ${PROJECT} -d development -h localhost:30081 -i \
 		--additional-distribution-dir s3://my-s3-bucket/fast/ --dest-dir /root/recipes ${CURDIR}/_pb_output/*
 
 .PHONY: in_container_fast_serialize_sandbox

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -24,6 +24,8 @@ serialize:
 
 .PHONY: register
 register:
+    test $(OUTPUT_DATA_PREFIX)
+    test $(FLYTE_HOST)
 	flyte-cli register-files ${INSECURE} -p flytetester -d development -v ${VERSION} --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} _pb_output/*
 
 .PHONY: fast_serialize

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -24,8 +24,8 @@ serialize:
 
 .PHONY: register
 register:
-    test $(OUTPUT_DATA_PREFIX)
-    test $(FLYTE_HOST)
+	test $(OUTPUT_DATA_PREFIX)
+	test $(FLYTE_HOST)
 	flyte-cli register-files ${INSECURE} -p flytetester -d development -v ${VERSION} --kubernetes-service-account default --output-location-prefix ${OUTPUT_DATA_PREFIX} -h ${FLYTE_HOST} _pb_output/*
 
 .PHONY: fast_serialize

--- a/cookbook/recipes/common/Makefile.common
+++ b/cookbook/recipes/common/Makefile.common
@@ -3,6 +3,10 @@
 IMAGE_NAME=flytecookbook
 VERSION=$(shell ./version.sh)
 
+# If you're port-forwarding your service or running the sandbox Flyte deployment you can leave this is as is.
+# If you want to use a secure channel with ssl enabled, be sure **not** to use the insecure flag.
+INSECURE=-i
+
 define PIP_COMPILE
 pip-compile $(1) --upgrade --verbose
 endef


### PR DESCRIPTION
- Add overridable insecure option for local deployments or port-forwarded endpoints (1. here https://github.com/flyteorg/flyte/issues/687)
- Use `default` k8s service account since the referenced `demo` one doesn't exist and executions fail at runtime (3. here https://github.com/flyteorg/flyte/issues/687)
- Also add checks for undefined make variables before running flyte-cli register commands
