### PR TITLE
streamline flytesnacks tutorials

### DIFF
--- a/cookbook/docs/case_studies.rst
+++ b/cookbook/docs/case_studies.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: case_studies
 
 ####################################################
-Case Studies: Real world examples of using flytekit
+Real world examples of using Flytekit
 ####################################################
 
 

--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -138,7 +138,6 @@ html_theme_options = {
     # Specify a base_url used to generate sitemap.xml. If not
     # specified, then no sitemap will be built.
     "base_url": "https://github.com/lyft/flytekit",
-    "collapse_navigation": False,
     # Set the color and the accent color
     "color_primary": "deep-purple",
     "color_accent": "blue",

--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -132,7 +132,7 @@ master_doc = "index"
 html_theme = "sphinx_material"
 html_theme_options = {
     # Set the name of the project to appear in the navigation.
-    "nav_title": "Flyte",
+    "nav_title": "Flyte Tutorials",
     # Set you GA account ID to enable tracking
     "google_analytics_account": "G-YQL24L5CKY",
     # Specify a base_url used to generate sitemap.xml. If not
@@ -146,16 +146,24 @@ html_theme_options = {
     "repo_url": "https://github.com/lyft/flyte/",
     "repo_name": "flyte",
     # Visible levels of the global TOC; -1 means unlimited
-    "globaltoc_depth": 1,
+    "globaltoc_depth": -1,
     # If False, expand all TOC entries
-    "globaltoc_collapse": False,
+    "globaltoc_collapse": True,
     # If True, show hidden TOC entries
     "globaltoc_includehidden": False,
-    "heroes": {"": "Flyte",},
+    # don't include home link in breadcrumb bar, since it's included
+    # in the nav_links key below.
+    "master_doc": False,
+    # custom nav in breadcrumb bar
+    "nav_links": [
+        {"href": "https://flyte.readthedocs.io/", "internal": False, "title": "Flyte"},
+        {"href": "index", "internal": True, "title": "Tutorials"},
+        {"href": "https://flytekit.readthedocs.io/en/latest/", "internal": False, "title": "Flytekit Python Reference"},
+    ],
 }
 
 html_sidebars = {
-    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
+    "**": ["logo-text.html", "globaltoc.html", "searchbox.html"]
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -146,9 +146,9 @@ html_theme_options = {
     "repo_url": "https://github.com/lyft/flyte/",
     "repo_name": "flyte",
     # Visible levels of the global TOC; -1 means unlimited
-    "globaltoc_depth": -1,
+    "globaltoc_depth": 1,
     # If False, expand all TOC entries
-    "globaltoc_collapse": True,
+    "globaltoc_collapse": False,
     # If True, show hidden TOC entries
     "globaltoc_includehidden": False,
     # don't include home link in breadcrumb bar, since it's included
@@ -163,7 +163,7 @@ html_theme_options = {
 }
 
 html_sidebars = {
-    "**": ["logo-text.html", "globaltoc.html", "searchbox.html"]
+    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/cookbook/docs/core.rst
+++ b/cookbook/docs/core.rst
@@ -3,7 +3,7 @@
 .. currentmodule:: core
 
 ############################################
-Getting Started with Flytekit [python]
+Getting Started with Flytekit Python
 ############################################
 The first three chapters of this part of the cookbook is organized into increasing levels of complexity. The last chapter shows the reader the optimal way to use flytekit with a live Flyte deployment.
 

--- a/cookbook/docs/index.rst
+++ b/cookbook/docs/index.rst
@@ -1,9 +1,9 @@
-Flyte Cookbook
+Flyte Tutorials
 ==============================================
-Flytesnacks is intended to be a ``learn by example`` style cookbook.  We cover all the various concepts in Flyte along with most of the maintained
-plugins. This cookbook is designed to get you running both locally, and on a Flyte cluster using `Flyte Python SDK (flytekit) <https://github.com/lyft/flytekit>`__
+These tutorials are intended to be a learn by example style cookbook.  We cover all the various concepts in Flyte along with most of the maintained
+plugins. This cookbook is designed to get you running both locally, and on a Flyte cluster using `Flytekit Python <https://github.com/lyft/flytekit>`__
 
-All the examples in this book are executable locally and we recommend the best way to try out Flyte is to run these examples in your terminal or IDE.
+All the examples are executable locally and we recommend the best way to try out Flyte is to run these examples in your terminal or IDE.
 If you have access to a whole Flyte platform deployment, this cookbook can also be used as a fully functional workflow repo.
 
 The tutorial is divided into 3 sections:
@@ -22,7 +22,7 @@ Please join our Slack channel as well through this `form <https://docs.google.co
 
 .. toctree::
    :maxdepth: 4
-   :caption: Getting Started
+   :caption: Examples
 
    tutorial
    core
@@ -49,13 +49,6 @@ Please join our Slack channel as well through this `form <https://docs.google.co
    auto_plugins_sagemaker_training/index
    auto_plugins_kfpytorch/index
    auto_plugins_sagemaker_pytorch/index
-
-.. toctree::
-   :maxdepth: 4
-   :caption: Additional Flyte Documentation
-
-   Flyte Project <https://flyte.readthedocs.io/en/latest/>
-   Flytekit Python <https://flytekit.readthedocs.io/en/latest/">
 
 
 Indices and tables

--- a/cookbook/docs/index.rst
+++ b/cookbook/docs/index.rst
@@ -4,8 +4,7 @@ These tutorials are intended to help the user learn by example. We start with va
 then introduce some of the core plugins. This cookbook is designed to get you running both locally, and on a Flyte cluster using
 `Flytekit Python <https://github.com/lyft/flytekit>`__
 
-All the examples are executable locally and we recommend the best way to try out Flyte is to run these examples in your terminal or IDE.
-If you have access to a whole Flyte platform deployment, this cookbook can also be used as a fully functional workflow repo.
+All the examples are authored using `Flytekit Python <https://github.com/lyft/flytekit>`__ and are designed to be run-locally (this may not be possible for some plugins) or on a Flyte cluster.
 
 The tutorial is divided into 3 sections:
 

--- a/cookbook/docs/index.rst
+++ b/cookbook/docs/index.rst
@@ -1,7 +1,8 @@
 Flyte Tutorials
 ==============================================
-These tutorials are intended to be a learn by example style cookbook.  We cover all the various concepts in Flyte along with most of the maintained
-plugins. This cookbook is designed to get you running both locally, and on a Flyte cluster using `Flytekit Python <https://github.com/lyft/flytekit>`__
+These tutorials are intended to help the user learn by example. We start with various concepts in flyte and flytekit with examples and
+then introduce some of the core plugins. This cookbook is designed to get you running both locally, and on a Flyte cluster using
+`Flytekit Python <https://github.com/lyft/flytekit>`__
 
 All the examples are executable locally and we recommend the best way to try out Flyte is to run these examples in your terminal or IDE.
 If you have access to a whole Flyte platform deployment, this cookbook can also be used as a fully functional workflow repo.

--- a/cookbook/docs/tutorial.rst
+++ b/cookbook/docs/tutorial.rst
@@ -2,7 +2,7 @@
 .. currentmodule:: flyte_tutorial
 
 ############################################
-Tutorial: Hello World!
+Hello World Example
 ############################################
 
 .. rubric:: Estimated time to complete: 3 minutes.


### PR DESCRIPTION
- make header nav consistent with `flyte` docs
- clarify copy
- remove "other documentation" section, instead make flyte and flytekit
  docs available on the navlink

Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>