### PR TITLE
Increased the request and limits for customize resource task

### DIFF
--- a/cookbook/core/remote_flyte/customizing_resources.py
+++ b/cookbook/core/remote_flyte/customizing_resources.py
@@ -36,7 +36,7 @@ import typing
 from flytekit import Resources, task, workflow
 
 
-@task(requests=Resources(cpu="1", mem="6Mi"), limits=Resources(cpu="2", mem="100Mi"))
+@task(requests=Resources(cpu="1", mem="100Mi"), limits=Resources(cpu="2", mem="150Mi"))
 def count_unique_numbers(x: typing.List[int]) -> int:
     s = set()
     for i in x:

--- a/cookbook/core/remote_flyte/customizing_resources.py
+++ b/cookbook/core/remote_flyte/customizing_resources.py
@@ -36,7 +36,7 @@ import typing
 from flytekit import Resources, task, workflow
 
 
-@task(requests=Resources(cpu="1", mem="2048"), limits=Resources(cpu="2", mem="4096"))
+@task(requests=Resources(cpu="1", mem="6Mi"), limits=Resources(cpu="2", mem="100Mi"))
 def count_unique_numbers(x: typing.List[int]) -> int:
     s = set()
     for i in x:


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

Not sure how this task is working for everyone which is part of the cookbooks but i ran into the following issues.
Configured defaults for the admin are the following.

```
task_resources:
  defaults:
    cpu: 100m
    gpu: 20m
    memory: 200Mi
    storage: 5Mi
  limits:
    cpu: 2
    gpu: 100m
    memory: 8Gi
    storage: 20Mi
```


Following were the different scenarios i tried.

1] If the configured cpu/ memory was too low  , the container creation failed and it kept recreating for 24 hours and I had to manually abort it the execution

```
@task(requests=Resources(cpu="1", mem="2048"), limits=Resources(cpu="2", mem="4096"))
```

```
Events:
  Type     Reason                  Age                 From               Message
  ----     ------                  ----                ----               -------
  Normal   Scheduled               80s                 default-scheduler  Successfully assigned flytectldemo-development/f22c936a82d404f91adc-n0-0 to docker-desktop
  Warning  FailedCreatePodSandBox  67s (x13 over 79s)  kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to start sandbox container for pod "f22c936a82d404f91adc-n0-0": Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: process_linux.go:352: getting the final child's pid from pipe caused: EOF: unknown
  Normal   SandboxChanged          67s (x12 over 78s)  kubelet            Pod sandbox changed, it will be killed and re-created.

```

The memory seems to low for container creation here.


2] If the configured limit is moderately low it fails but this time the workflow also fails immediately

```
@task(requests=Resources(cpu="1", mem="2Mi"), limits=Resources(cpu="2", mem="4Mi"))
```

The 6MB might be different in different kubernetes cluster . Not sure where this is configured though.

```
Events:
  Type     Reason          Age               From               Message
  ----     ------          ----              ----               -------
  Normal   Scheduled       40s               default-scheduler  Successfully assigned flytectldemo-development/f69425edf16b44475b04-n0-0 to docker-desktop
  Normal   Pulled          1s (x8 over 38s)  kubelet            Container image "flytecookbook:core-2abf65d228b50e8d04d2848a524884a87ef3d477" already present on machine
  Warning  Failed          1s (x8 over 38s)  kubelet            Error: Error response from daemon: Minimum memory limit allowed is 6MB
  Normal   SandboxChanged  0s (x8 over 37s)  kubelet            Pod sandbox changed, it will be killed and re-created.
```

3] It fails even with the following memory limits and the container creation fails with OOMKilled 

Increased the memory above 6MB but it still failed this time with OOM on the POD
```
@task(requests=Resources(cpu="1", mem="6Mi"), limits=Resources(cpu="2", mem="10Mi"))
```


4] Following resource limits worked for the task

```
@task(requests=Resources(cpu="1", mem="6Mi"), limits=Resources(cpu="2", mem="100Mi"))
```

