### PR TITLE
Update task_cache.py file to fix broken code snippet

### DIFF
--- a/cookbook/core/flyte_basics/task_cache.py
+++ b/cookbook/core/flyte_basics/task_cache.py
@@ -39,10 +39,11 @@ def square(n: int) -> int:
 # %%
 # If, in a subsequent code update, we update the signature of the task to return the original number along with the result, it'll automatically invalidate the cache (even though the cache version remains the same). ::
 #
-#   :py:func:`flytekit.task`
-#   @task(cache=True, cache_version="1.0")
-#   def square(n: int) -> (int, int):
-#       ...
+# :py:func:`flytekit.task`
+@task(cache=True, cache_version="1.0")
+def square(n: int) -> (int, int):
+    ...
 
+    
 # %%
 # To read more about Task caching and how a unique signature is calculated, please proceed to the `Task Cache documentation <please insert correct link>`__.


### PR DESCRIPTION
Currently this snippet isn't correctly rendered: https://docs.flyte.org/projects/cookbook/en/latest/auto_core_flyte_basics/task_cache.html

<img width="946" alt="Screenshot 2021-05-04 at 18 06 21" src="https://user-images.githubusercontent.com/1027207/117042083-70912680-ad03-11eb-92c6-cf403c1bdeef.png">
