### PR TITLE
Find broken links within the docs

### DIFF
--- a/cookbook/docs/Makefile
+++ b/cookbook/docs/Makefile
@@ -6,6 +6,10 @@ rsts:
 html:
 	sphinx-build -n -b html . _build && sphinx-build -n -b doctest . _build
 
+.PHONY: linkcheck
+linkcheck:
+	sphinx-build -n -b linkcheck . _build
+
 .PHONY: clean
 clean:
 	rm -rf _build


### PR DESCRIPTION
Signed-off-by: Samhita Alla <aallasamhita@gmail.com>

* `-b linkcheck` notifies broken external links
* `-n` mode notifies broken internal links within the docs

We can copy this make target to repos where docs is being generated.