### PR TITLE
hide download button for examples that don't contain python

### DIFF
--- a/cookbook/docs/_static/sphx_gallery_autogen.css
+++ b/cookbook/docs/_static/sphx_gallery_autogen.css
@@ -1,0 +1,22 @@
+
+#sphx-glr-download-auto-core-containerization-workflow-labels-annotations-py,
+#sphx-glr-download-auto-deployment-workflow-fast-registration-py,
+#sphx-glr-download-auto-deployment-workflow-multiple-k8s-py,
+#sphx-glr-download-auto-deployment-cluster-productionize-cluster-py,
+#sphx-glr-download-auto-deployment-cluster-optimize-perf-py,
+#sphx-glr-download-auto-deployment-cluster-access-cloud-resources-py,
+#sphx-glr-download-auto-deployment-cluster-monitoring-py,
+#sphx-glr-download-auto-deployment-cluster-auth-setup-py,
+#sphx-glr-download-auto-deployment-cluster-config-resource-mgr-py,
+#sphx-glr-download-auto-deployment-cluster-notifications-py,
+#sphx-glr-download-auto-deployment-cluster-config-flyte-deploy-py,
+#sphx-glr-download-auto-deployment-guides-aws-py,
+#sphx-glr-download-auto-deployment-guides-kubernetes-py,
+#sphx-glr-download-auto-deployment-guides-gcp-py,
+#sphx-glr-download-auto-control-plane-register-project-py,
+#sphx-glr-download-auto-control-plane-run-task-py,
+#sphx-glr-download-auto-control-plane-run-workflow-py,
+#sphx-glr-download-auto-core-extend-flyte-backend-plugins-py {
+    height: 0px;
+    visibility: hidden;
+}

--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -159,6 +159,8 @@ templates_path = ["_templates"]
 
 html_static_path = ["_static"]
 
+html_css_files = ["sphx_gallery_autogen.css"]
+
 # generate autosummary even if no references
 autosummary_generate = True
 
@@ -324,12 +326,53 @@ if len(examples_dirs) != len(gallery_dirs):
 # The main one is the the gallery's entrypoint is a README.rst file and the rest
 # of the files are *.py files that are auto-converted to .rst files. This makes
 # sure that the only rst files in the example directories are README.rst
+hide_download_page_ids = []
+
+def hide_example_page(file_handler):
+    """Heuristic that determines whether example file contains python code."""
+    example_content = file_handler.read().strip()
+
+    no_percent_comments = True
+    no_imports = True
+
+    for line in example_content.split("\n"):
+        if line.startswith(r"# %%"):
+            no_percent_comments = False
+        if line.startswith("import"):
+            no_imports = False
+
+    return example_content.startswith('"""') and example_content.endswith('"""') and no_percent_comments and no_imports
+
 for source_dir in sphinx_gallery_conf["examples_dirs"]:
     for f in Path(source_dir).glob("*.rst"):
         if f.name != "README.rst":
             raise ValueError(
                 f"non-README.rst file {f} not permitted in sphinx gallery directories"
             )
+
+    # we want to hide the download example button in pages that don't actually contain python code.
+    for f in Path(source_dir).glob("*.py"):
+        with f.open() as fh:
+            if hide_example_page(fh):
+                page_id = str(f).replace("..", "auto").replace("/", "-").replace(".", "-").replace("_", "-")
+                hide_download_page_ids.append(f"sphx-glr-download-{page_id}")
+
+SPHX_GALLERY_CSS_TEMPLATE = \
+"""
+{hide_download_page_ids} {{
+    height: 0px;
+    visibility: hidden;
+}}
+"""
+
+with Path("_static/sphx_gallery_autogen.css").open("w") as f:
+    f.write(
+        SPHX_GALLERY_CSS_TEMPLATE.format(
+            hide_download_page_ids=",\n".join(
+                f"#{x}" for x in hide_download_page_ids
+            )
+        )
+    )
 
 # intersphinx configuration
 intersphinx_mapping = {


### PR DESCRIPTION
since all example files in the user guide and tutorial are .py
files with the exception of README.rst, we want to hide the download
button for pages with no actual python code. This diff adds logic
to conf.py that auto-generates a css file that achieves this.

Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>