### PR TITLE
fix pyspark_py.py example headers

### DIFF
--- a/cookbook/integrations/kubernetes/k8s_spark/pyspark_pi.py
+++ b/cookbook/integrations/kubernetes/k8s_spark/pyspark_pi.py
@@ -20,13 +20,13 @@ Managing Python dependencies is hard. Flyte makes it easy to version and manage 
 to spark without needing to manage special spark clusters.
 
 Pros:
-------
+^^^^^
 #. Extremely easy to get started and get complete isolation between workloads
 #. Every job runs in isolation and has its own virtual cluster - no more nightmarish dependency management
 #. Flyte manages everything for you!
 
 Cons:
------
+^^^^^
 #. Short running, bursty jobs are not a great fit - because of the container overhead
 #. No interactive spark capabilities available with Flyte K8s spark, which is more suited for running, adhoc and/or scheduled jobs
 


### PR DESCRIPTION
This PR fixes error in pyspark_pi.py file where the pros and cons headers were showing up in the sidebar:

![image](https://user-images.githubusercontent.com/2816689/120860231-51c8be80-c553-11eb-9718-903589b8ecc4.png)


Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>