### PR TITLE
Update Makefile to add entries for `start` and `shell` to `make help`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ update_boilerplate:
 	@boilerplate/update.sh
 
 .PHONY: help
-help: ## show help message
+help: ## Show help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[$$()% a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 # Helper to determine if a sandbox is up and running
@@ -64,9 +64,8 @@ setup:
 wait:
 	$(call RUN_IN_SANDBOX, wait-for-flyte.sh)
 
-## Start a local Flyte sandbox
 .PHONY: start
-start: setup wait
+start: setup wait ## Start a local Flyte sandbox
 	$(call LOG,Registering examples from commit: latest)
 	REGISTRY=cr.flyte.org/flyteorg VERSION=latest $(call RUN_IN_SANDBOX,make -C cookbook/$(EXAMPLES_MODULE) fast_register)
 
@@ -82,7 +81,7 @@ status: _requires-sandbox-up  ## Show status of Flyte deployment
 	kubectl get pods -n flyte
 
 .PHONY: shell
-shell: _requires-sandbox-up  # Drop into a development shell
+shell: _requires-sandbox-up  ## Drop into a development shell
 	$(call RUN_IN_SANDBOX,bash)
 
 .PHONY: register


### PR DESCRIPTION
# TL;DR
See title.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Currently `make help` doesn't show hints for `start` and `shell`. This small change exposes these two commands by moving comments to the end of target definition so that the awk magic picks them up.
Before:
<img width="473" alt="Screen Shot 2021-06-16 at 17 28 15" src="https://user-images.githubusercontent.com/6239450/122441523-7872f600-cf52-11eb-9965-7d91430d31ab.png">
After
<img width="473" alt="Screen Shot 2021-06-16 at 17 29 11" src="https://user-images.githubusercontent.com/6239450/122441533-7c067d00-cf52-11eb-9450-fdf77aa801a5.png">