### PR TITLE
render mermaid diagrams in tabs on click event

### DIFF
--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -426,3 +426,4 @@ sphinx_tabs_valid_builders = ['linkcheck']
 # Sphinx-mermaid config
 mermaid_output_format = 'raw'
 mermaid_version = 'latest'
+mermaid_init_js = "mermaid.initialize({startOnLoad:false});"


### PR DESCRIPTION
https://github.com/flyteorg/furo/commit/696cb9fe168cadb6f0da17400085c15e73e8c1f7
introduces logic to the furo template that makes sure raw mermaid diagram
markup is only rendered on click events when that diagram is embedded in
a hidden tab.

Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>