### PR TITLE
Refactor release workflow and Added flytectl new flags 

### DIFF
--- a/.github/workflows/release_examples.yml
+++ b/.github/workflows/release_examples.yml
@@ -1,12 +1,16 @@
 name: Serialize & Release Examples
 
 on:
+  pull_request:
+    paths-ignore:
+      - 'cookbook/docs/**'
+      - 'cookbook/deployment/**'
   create:
     tags:
       - v*
 
 jobs:
-  serialize-example:
+  release-serialized-example:
     name: Serialize
     strategy:
       matrix:
@@ -16,53 +20,41 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
-      - uses: actions/cache@v1
-        with:
-          path: /tmp/release-snacks-${{ matrix.directory }}/
-          key: release-snacks-${{ matrix.directory }}-${{ github.sha }}
       - name: Serialize Examples
         env:
           REGISTRY: "ghcr.io/flyteorg"
         run: |
           REGISTRY=ghcr.io/flyteorg VERSION=latest make -C cookbook/${{ matrix.directory }} serialize
-      - name: Cache Serialized protos
+      - name: Archive Serialized protos
         env:
           REGISTRY: "ghcr.io/flyteorg"
         run: |
-          mkdir -p cookbook/release-snacks /tmp/release-snacks-${{ matrix.directory }}/
+          mkdir -p cookbook/release-snacks
           make -C cookbook archive
-          cp -r cookbook/release-snacks/ /tmp/release-snacks-${{ matrix.directory }}/*
-  releaser:
-    name: Release example
+      - name: Run GoReleaser
+        if: github.event_name != 'pull_request'
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.FLYTE_BOT_PAT }}
+
+  release-manifest:
+    name: Release Manifest
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    needs: [ serialize-example ]
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
-      - uses: actions/cache@v1
-        with:
-          path: /tmp/release-snacks-core/
-          key: release-snacks-core-${{ github.sha }}
-      - uses: actions/cache@v1
-        with:
-          path: /tmp/release-snacks-case_studies/
-          key: release-snacks-case_studies-${{ github.sha }}
-      - uses: actions/cache@v1
-        with:
-          path: /tmp/release-snacks-integrations/
-          key: release-snacks-integrations-${{ github.sha }}
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
-          ref: ${{ steps.bump-version.outputs.tag }}
-      - name: Copy artifacts
+      - name: Serialize Examples
+        env:
+          REGISTRY: "ghcr.io/flyteorg"
         run: |
           mkdir -p cookbook/release-snacks
-          cp -r /tmp/release-snacks-core/* cookbook/release-snacks/
-          cp -r /tmp/release-snacks-case_studies/* cookbook/release-snacks/
-          cp -r /tmp/release-snacks-integrations/* cookbook/release-snacks/
-      - name: Run GoReleaser
+          cp cookbook/flyte_tests_manifest.json cookbook/release-snacks/flyte_tests_manifest.json
+      - name: Release test manifest
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/sandbox_register.yml
+++ b/.github/workflows/sandbox_register.yml
@@ -5,8 +5,6 @@ on:
     paths-ignore:
       - 'cookbook/docs/**'
       - 'cookbook/deployment/**'
-    branches:
-      - master
 
 defaults:
   run:
@@ -23,6 +21,6 @@ jobs:
           fetch-depth: "0"
       - uses: unionai/flytectl-setup-action@v0.0.1
       - name: setup sandbox
-        run: flytectl sandbox start --sourcesPath=$GITHUB_WORKSPACE
+        run: make setup
       - name: fast register
         run: REGISTRY=ghcr.io/flyteorg VERSION=latest make fast_register

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _build/
 *-out.html
 *-out.ipynb
 .python-version
+cookbook/release-snacks

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,5 +10,4 @@ release:
   name_template: "{{.ProjectName}} v{{.Version}}"
   disable: false
   extra_files:
-    - glob: ./cookbook/release-snacks/*.tgz
-    - glob: ./cookbook/flyte_tests_manifest.json
+    - glob: ./cookbook/release-snacks/*

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 .PHONY: setup
 setup:
 	$(call LOG,Starting Flyte sandbox)
-	flytectl sandbox start --sourcesPath=$(shell pwd)
+	flytectl sandbox start --source=$(shell pwd)
 
 .PHONY: start
 start: setup

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Here are the setup instructions to start contributing to `flytesnacks` repo:
 4. Test your code!
     * If the Python code can be run locally, just use `python <my file>` to run it.
     * If the Python code has to be tested in a cluster:
+        * Install flytectl by running `brew install flyteorg/homebrew-tap/flytectl`. Learn more about install and configuration of [flytectl](https://docs.flyte.org/projects/flytectl/en/latest/index.html) 
         * Run the `make start` command in the root directory of the flytesnacks repo
         * Visit https://localhost:30081 to view the Flyte console consisting of the examples present in flytesnacks/cookbook/core directory
         * To fetch new dependencies and rebuild the image, run `make register`

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -31,8 +31,5 @@ run-examples: ## Runs all examples
 
 .PHONY: archive
 archive: # archive directories (e.g. _pb_output/)
-	bash scripts/ci_helper.sh RELEASE
+	bash scripts/ci_helper.sh
 
-.PHONY: register-workflow-ci
-register-workflow-ci:
-	bash scripts/ci_helper.sh REGISTER

--- a/cookbook/scripts/ci_helper.sh
+++ b/cookbook/scripts/ci_helper.sh
@@ -2,22 +2,8 @@
 
 set -e
 
-release_example() {
-  for row in $(cat flyte_tests_manifest.json | jq -c '.[]'); do
-    if [ -d "./$(echo ${row} | jq -r '.path')/_pb_output/" ]; then
-      tar -cvzf "./release-snacks/flytesnacks-$(echo ${row} | jq -r '.name').tgz"  "./$(echo ${row} | jq -r '.path')/_pb_output/"
-    fi
-  done
-}
-
-register_example() {
-  for row in $(cat flyte_tests_manifest.json | jq -c '.[]'); do
-    flytectl register file "./release-snacks/flytesnacks-$(echo ${row} | jq -r '.name').tgz" -p flytesnacks -d development --archive
-  done
-}
-
-if [ "$1" == "RELEASE" ]; then
-  release_example
-elif [ $1 == "REGISTER" ]; then
-  register_example
-fi
+for row in $(cat flyte_tests_manifest.json | jq -c '.[]'); do
+  if [ -d "./$(echo ${row} | jq -r '.path')/_pb_output/" ]; then
+    tar -cvzf "./release-snacks/flytesnacks-$(echo ${row} | jq -r '.name').tgz"  "./$(echo ${row} | jq -r '.path')/_pb_output/"
+  fi
+done


### PR DESCRIPTION
- Removed cache from the workflow in release (Cache doesn't support sha in the key name)
- Used goreleaser for releasing all component individual 
- Refactor shell Script
- I reverted my pr that migrate register from flyte-cli to flytectl. So some changes are reverted, I added those change in this refactor

Test Result- 
1 - https://github.com/evalsocket/flytesnacks/runs/2965668184?check_suite_focus=true
2 - https://github.com/evalsocket/flytesnacks/releases/tag/v0.2.137