### PR TITLE
docs: update README to work with non-core examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Here are the setup instructions to start contributing to `flytesnacks` repo:
         * Run the `make start` command in the root directory of the flytesnacks repo
         * Visit https://localhost:30081 to view the Flyte console consisting of the examples present in flytesnacks/cookbook/core directory
         * To fetch new dependencies and rebuild the image, run `make register`
-        * If examples from a different directory (other than `core`) have to registered, run the command `SANDBOX=1 make -C <directory> register` in the `flytesnacks` repo.
+        * If examples from a different directory (other than `core`) have to registered, enter the sandbox first: `make shell` and then run `make -C <directory> register`.
 
 ### 📝 Contribute to documentation
 


### PR DESCRIPTION
fix from https://github.com/flyteorg/flyte/issues/1319#issuecomment-898857618

I think there's probably something in the Makefile that means `SANDBOX=1 make -C <directory> register` doesn't work, but given @kumare3 has plans to align more with the getting started guide I've just left this as a small README update for now.