### PR TITLE
Moved the scheduled workflows examples to core

### DIFF
--- a/cookbook/core/scheduled_workflows/README.rst
+++ b/cookbook/core/scheduled_workflows/README.rst
@@ -3,6 +3,6 @@
 Scheduling Workflows
 --------------------
 
-This module explains on how to create and launch scheduled workflows in flyte
+This module explains on how to create and launch scheduled workflows.
 Flyte supports both cron based and fixed rate schedules.
 

--- a/cookbook/core/scheduled_workflows/README.rst
+++ b/cookbook/core/scheduled_workflows/README.rst
@@ -3,7 +3,6 @@
 Scheduling Workflows
 --------------------
 
-For background on launch plans, refer to :any:`launch_plans`.
+This module explains on how to create and launch scheduled workflows in flyte
+Flyte supports both cron based and fixed rate schedules.
 
-Launch plans can be set to run automatically on a schedule using the flyte native scheduler which is enabled by default in sandbox environment
-For workflows that depend on knowing the kick-off time, Flyte also supports passing in the scheduled time (not the actual time, which may be a few seconds off) as an argument to the workflow.

--- a/cookbook/core/scheduled_workflows/README.rst
+++ b/cookbook/core/scheduled_workflows/README.rst
@@ -1,0 +1,9 @@
+.. _scheduled_workflows:
+
+Scheduling Workflows
+--------------------
+
+For background on launch plans, refer to :any:`launch_plans`.
+
+Launch plans can be set to run automatically on a schedule using the flyte native scheduler which is enabled by default in sandbox environment
+For workflows that depend on knowing the kick-off time, Flyte also supports passing in the scheduled time (not the actual time, which may be a few seconds off) as an argument to the workflow.

--- a/cookbook/core/scheduled_workflows/lp_schedules.py
+++ b/cookbook/core/scheduled_workflows/lp_schedules.py
@@ -2,11 +2,13 @@
 Scheduling Workflows
 --------------------
 For background on launch plans, refer to :any:`launch_plans`.
-Launch plans can be set to run automatically on a schedule if the Flyte platform is properly configured.
+Launch plans can be set to run automatically on a schedule using the flyte native scheduler.
 For workflows that depend on knowing the kick-off time, Flyte also supports passing in the scheduled time (not the actual time, which may be a few seconds off) as an argument to the workflow. 
 
-.. note:
+.. note::
+
   Native scheduler doesn't support `AWS syntax <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions>`_.
+
 """
 
 # %%
@@ -57,7 +59,7 @@ cron_lp = LaunchPlan.get_or_create(
 # ####################
 #     
 # If you prefer to use an interval rather than a cron scheduler to schedule your workflows, you can use the fixed-rate scheduler. 
-# A fixed-rate scheduler runs at the specified interval and is currently supported for Flyte deployments hosted on AWS.
+# A fixed-rate scheduler runs at the specified interval.
 #
 # Here's an example:
 

--- a/cookbook/core/scheduled_workflows/lp_schedules.py
+++ b/cookbook/core/scheduled_workflows/lp_schedules.py
@@ -1,3 +1,11 @@
+"""
+Scheduling Workflows
+--------------------
+For background on launch plans, refer to :any:`launch_plans`.
+Launch plans can be set to run automatically on a schedule if the Flyte platform is properly configured.
+For workflows that depend on knowing the kick-off time, Flyte also supports passing in the scheduled time (not the actual time, which may be a few seconds off) as an argument to the workflow. 
+"""
+
 # %%
 # Consider the following example workflow:
 from datetime import datetime

--- a/cookbook/core/scheduled_workflows/lp_schedules.py
+++ b/cookbook/core/scheduled_workflows/lp_schedules.py
@@ -4,6 +4,9 @@ Scheduling Workflows
 For background on launch plans, refer to :any:`launch_plans`.
 Launch plans can be set to run automatically on a schedule if the Flyte platform is properly configured.
 For workflows that depend on knowing the kick-off time, Flyte also supports passing in the scheduled time (not the actual time, which may be a few seconds off) as an argument to the workflow. 
+
+.. note:
+  Native scheduler doesn't support `AWS syntax <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions>`_.
 """
 
 # %%
@@ -40,7 +43,6 @@ cron_lp = LaunchPlan.get_or_create(
     workflow=date_formatter_wf,
     schedule=CronSchedule(
         # Note that kickoff_time_input_arg matches the workflow input we defined above: kickoff_time
-        # Native scheduler doesn't support `AWS syntax <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions>`_.
         # But in case you are using the AWS scheme of schedules and not using the native scheduler then switch over the schedule parameter with cron_expression
         schedule="*/1 * * * *", # Following schedule runs every min 
         kickoff_time_input_arg="kickoff_time",
@@ -143,10 +145,10 @@ fixed_rate_lp = LaunchPlan.get_or_create(
 #       flytectl get launchplan -p flytesnacks -d development``
 
 # %%        
-# Platform Configuration Changes
-# ##############################
+# Platform Configuration Changes For AWS Scheduler
+# ################################################
 # 
-# Scheduling features require additional infrastructure to run, so these will have to be created and configured.
+# Scheduling feature can be run using the flyte native scheduler which comes with flyte but if you intend to use the AWS scheduler then it require additional infrastructure to run, so these will have to be created and configured.The following sections are only required if you use AWS scheme for the scheduler. You can even run the flyte native scheduler on AWS though
 # 
 # Setting up Scheduled Workflows
 # ==============================
@@ -207,7 +209,7 @@ fixed_rate_lp = LaunchPlan.get_or_create(
 #        accountId: "{{ YOUR ACCOUNT ID }}"
 
 # %%            
-# * **scheme**: in this case because AWS is the only cloud back-end supported for executing scheduled workflows, only ``"aws"`` is a valid value. By default, the no-op executor is used.
+# * **scheme**: in this case because AWS is the only cloud back-end supported for executing scheduled workflows, only ``"aws"`` is a valid value. By default, the no-op executor is used and in case of sandbox we use ``"local"`` scheme which uses the flyte native scheduler.
 # * **region**: this specifies which region AWS clients should will use when creating an SQS subscriber client
 # * **scheduleQueueName**: this is the name of the SQS Queue you've allocated to scheduling workflows
 # * **accountId**: Your AWS `account id <https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#FindingYourAWSId>`_

--- a/cookbook/core/scheduled_workflows/lp_schedules.py
+++ b/cookbook/core/scheduled_workflows/lp_schedules.py
@@ -1,13 +1,3 @@
-"""
-Scheduling Workflows
---------------------
-
-For background on launch plans, refer to :any:`launch_plans`.
-
-Launch plans can be set to run automatically on a schedule if the Flyte platform is properly configured.
-For workflows that depend on knowing the kick-off time, Flyte also supports passing in the scheduled time (not the actual time, which may be a few seconds off) as an argument to the workflow. 
-"""
-
 # %%
 # Consider the following example workflow:
 from datetime import datetime
@@ -32,8 +22,8 @@ def date_formatter_wf(kickoff_time: datetime):
 # Cron Schedules
 # ##############
 #
-# Cron expression strings use the `AWS syntax <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions>`_.
-# These are validated at launch plan registration time.
+# Cron expression strings use the following `syntax <https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format>`_.
+# An incorrect cron schedule expression would lead to failure in triggering the schedule
 from flytekit import CronSchedule, LaunchPlan
 
 # creates a launch plan that runs at 10am UTC every day.
@@ -42,7 +32,9 @@ cron_lp = LaunchPlan.get_or_create(
     workflow=date_formatter_wf,
     schedule=CronSchedule(
         # Note that kickoff_time_input_arg matches the workflow input we defined above: kickoff_time
-        cron_expression="0 10 * * ? *",
+        # Native scheduler doesn't support `AWS syntax <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions>`_.
+        # But in case you are using the AWS scheme of schedules and not using the native scheduler then switch over the schedule parameter with cron_expression
+        schedule="*/1 * * * *", # Following schedule runs every min 
         kickoff_time_input_arg="kickoff_time",
     ),
 )

--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -56,6 +56,7 @@ class CustomSorter(FileNameSortKey):
         "typed_schema.py",
         "custom_objects.py",
         "enums.py",
+        "lp_schedules.py",
         # Testing
         "mocking.py",
         # Containerization
@@ -74,7 +75,6 @@ class CustomSorter(FileNameSortKey):
         # Deployment
         ## Workflow
         "deploying_workflows.py",
-        "lp_schedules.py",
         "customizing_resources.py",
         "lp_notifications.py",
         "fast_registration.py",

--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -271,7 +271,7 @@ examples_dirs = [
 gallery_dirs = [
     "auto/core/flyte_basics",
     "auto/core/control_flow",
-    "auto/core/scheduled_worflows",
+    "auto/core/scheduled_workflows",
     "auto/core/type_system",
     "auto/case_studies/ml_training/pima_diabetes",
     "auto/case_studies/ml_training/house_price_prediction",

--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -241,6 +241,7 @@ html_logo = "_static/flyte_circle_gradient_1_4x4.png"
 examples_dirs = [
     "../core/flyte_basics",
     "../core/control_flow",
+    "../core/scheduled_workflows",
     "../core/type_system",
     "../case_studies/ml_training/pima_diabetes",
     "../case_studies/ml_training/house_price_prediction",
@@ -270,6 +271,7 @@ examples_dirs = [
 gallery_dirs = [
     "auto/core/flyte_basics",
     "auto/core/control_flow",
+    "auto/core/scheduled_worflows",
     "auto/core/type_system",
     "auto/case_studies/ml_training/pima_diabetes",
     "auto/case_studies/ml_training/house_price_prediction",

--- a/cookbook/docs/index.rst
+++ b/cookbook/docs/index.rst
@@ -50,6 +50,15 @@ Table of Contents
 
    ---
 
+   .. link-button:: auto/core/scheduled_workflows/index
+      :type: ref
+      :text: ⏱ Scheduled Workflows
+      :classes: btn-block stretched-link
+   ^^^^^^^^^^^^
+   Learn about scheduled workflows.
+
+   ---
+
    .. link-button:: auto/testing/index
       :type: ref
       :text: ⚗️ Testing


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

Now that we support native scheduler in sandbox the existing scheduled workflows which used to run only in AWS environment can now be run in sandbox environment

Tested these changes by installing the sandbox using helm charts with scheduler enabled.
* flytectl register file  /Users/praful/flytesnacks/cookbook/core/_pb_output/*   -d development  -p flytesnacks --version v1
* flytectl update launchplan -p flytesnacks -d development my_fixed_rate_lp  --version v1 --activate
* flytectl update launchplan -p flytesnacks -d development my_cron_scheduled_lp  --version v1 --activate

Saw the schedules being triggered on a regular cadence based on the cron or fixed schedule


Docs available here : https://flyte--413.org.readthedocs.build/projects/cookbook/en/413/