### PR TITLE
`make start` attempts to fast_register inside container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,7 @@ setup:
 	flytectl config init
 
 .PHONY: start
-start: setup
-	$(call LOG,Registering examples from commit: latest)
-	REGISTRY=cr.flyte.org/flyteorg VERSION=latest $(call RUN_IN_SANDBOX,make -C cookbook/$(EXAMPLES_MODULE) fast_register)
-
+start: setup fast_register
 	echo "Flyte is ready! Flyte UI is available at http://localhost:$(FLYTE_PROXY_PORT)/console."
 
 .PHONY: teardown


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

`flytectl` version inside the sandbox image is apparently old and doesn't support the newish `--k8sServiceAccount` flag. This causes `make start` to fail.

We are moving towards running flytectl natively on users' machines. It makes sense to move this registration as well..