### PR TITLE
Reduce resource request in spark horovod

### DIFF
--- a/cookbook/case_studies/ml_training/spark_horovod/keras_spark_rossmann_estimator.py
+++ b/cookbook/case_studies/ml_training/spark_horovod/keras_spark_rossmann_estimator.py
@@ -95,8 +95,8 @@ class Hyperparameters:
     ),
     cache=True,
     cache_version="0.2",
-    requests=Resources(mem="2Gi"),
-    limits=Resources(mem="2Gi"),
+    requests=Resources(mem="1Gi"),
+    limits=Resources(mem="1Gi"),
 )
 def estimate(data_dir: FlyteDirectory, hp: Hyperparameters, work_dir: FlyteDirectory) -> FlyteDirectory:
     # ================ #


### PR DESCRIPTION
Spark horovod example is failing because sandbox doesn't have enough resources. Reduce the memory requirement from 2GB -> 1 GB


Fail CI:- https://github.com/flyteorg/flytectl/pull/199/checks?check_run_id=3925396417#step:7:134