### PR TITLE
fix registry name  in release

### DIFF
--- a/.github/workflows/sandbox_register.yml
+++ b/.github/workflows/sandbox_register.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           SANDBOX: "1"
         run: |
-          make -C ${{ matrix.directory }} serialize
+          REGISTRY=ghcr.io/flyteorg make -C ${{ matrix.directory }} serialize
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
- In New CI changes we serialize workflows without a registry. Just added ghcr registry in serialize