### PR TITLE
Use non-root user in flytesnacks containers

### DIFF
--- a/cookbook/case_studies/in_container.mk
+++ b/cookbook/case_studies/in_container.mk
@@ -11,7 +11,6 @@ $(SERIALIZED_PB_OUTPUT_DIR): clean
 serialize: $(SERIALIZED_PB_OUTPUT_DIR)
 	pyflyte --config /root/sandbox.config serialize workflows -f $(SERIALIZED_PB_OUTPUT_DIR)
 
-
 .PHONY: fast_serialize
 fast_serialize: $(SERIALIZED_PB_OUTPUT_DIR)
 	pyflyte --config /root/sandbox.config serialize fast workflows -f $(SERIALIZED_PB_OUTPUT_DIR)

--- a/cookbook/common/leaf.mk
+++ b/cookbook/common/leaf.mk
@@ -88,6 +88,7 @@ fast_serialize: clean _pb_output
 		-e ADDL_DISTRIBUTION_DIR=${ADDL_DISTRIBUTION_DIR} \
 		-e SERVICE_ACCOUNT=$(SERVICE_ACCOUNT) \
 		-e VERSION=${VERSION} \
+		-u root \
 		-v ${CURDIR}/_pb_output:/tmp/output \
 		-v ${CURDIR}:/root/$(shell basename $(CURDIR)) \
 		${TAGGED_IMAGE} make fast_serialize
@@ -129,6 +130,7 @@ serialize: clean _pb_output docker_build
 		-e ADDL_DISTRIBUTION_DIR=${ADDL_DISTRIBUTION_DIR} \
 		-e SERVICE_ACCOUNT=$(SERVICE_ACCOUNT) \
 		-e VERSION=${VERSION} \
+		-u root \
 		-v ${CURDIR}/_pb_output:/tmp/output \
 		${TAGGED_IMAGE} make serialize
 

--- a/cookbook/core/Dockerfile
+++ b/cookbook/core/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /root
 ENV VENV /opt/venv
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
-ENV PYTHONPATH /root
 
 # This is necessary for opencv to work
 RUN apt-get update && apt-get install -y libsm6 libxext6 libxrender-dev ffmpeg build-essential
@@ -19,7 +18,6 @@ RUN apt-get install curl --assume-yes
 RUN curl -sSL https://sdk.cloud.google.com | bash
 ENV PATH $PATH:/root/google-cloud-sdk/bin
 
-
 ENV VENV /opt/venv
 # Virtual environment
 RUN python3 -m venv ${VENV}
@@ -31,8 +29,9 @@ RUN pip install -r /root/requirements.txt
 
 # Create non-root user for entrypoint into container
 RUN useradd -m nonroot
-WORKDIR /home/nonroot
 USER nonroot
+WORKDIR /home/nonroot
+ENV PYTHONPATH /home/nonroot
 
 # Copy the makefile targets to expose on the container. This makes it easier to register
 COPY in_container.mk /home/nonroot/Makefile

--- a/cookbook/core/Dockerfile
+++ b/cookbook/core/Dockerfile
@@ -29,12 +29,17 @@ ENV PATH="${VENV}/bin:$PATH"
 COPY core/requirements.txt /root
 RUN pip install -r /root/requirements.txt
 
+# Create non-root user for entrypoint into container
+RUN useradd -m nonroot
+WORKDIR /home/nonroot
+USER nonroot
+
 # Copy the makefile targets to expose on the container. This makes it easier to register
-COPY in_container.mk /root/Makefile
-COPY core/sandbox.config /root
+COPY in_container.mk /home/nonroot/Makefile
+COPY core/sandbox.config /home/nonroot
 
 # Copy the actual code
-COPY core /root/core
+COPY core /home/nonroot/core
 
 # This tag is supplied by the build script and will be used to determine the version
 # when registering tasks, workflows, and launch plans

--- a/cookbook/core/Dockerfile
+++ b/cookbook/core/Dockerfile
@@ -29,16 +29,17 @@ RUN pip install -r /root/requirements.txt
 
 # Create non-root user for entrypoint into container
 RUN useradd -m nonroot
+
+# Copy the makefile targets to expose on the container. This makes it easier to register
+COPY --chown=nonroot:nonroot in_container.mk /home/nonroot/Makefile
+COPY --chown=nonroot:nonroot core/sandbox.config /home/nonroot
+
+# Copy the actual code
+COPY --chown=nonroot:nonroot core /home/nonroot/core
+
 USER nonroot
 WORKDIR /home/nonroot
 ENV PYTHONPATH /home/nonroot
-
-# Copy the makefile targets to expose on the container. This makes it easier to register
-COPY in_container.mk /home/nonroot/Makefile
-COPY core/sandbox.config /home/nonroot
-
-# Copy the actual code
-COPY core /home/nonroot/core
 
 # This tag is supplied by the build script and will be used to determine the version
 # when registering tasks, workflows, and launch plans

--- a/cookbook/core/in_container.mk
+++ b/cookbook/core/in_container.mk
@@ -9,8 +9,8 @@ $(SERIALIZED_PB_OUTPUT_DIR): clean
 
 .PHONY: serialize
 serialize: $(SERIALIZED_PB_OUTPUT_DIR)
-	pyflyte --config /root/sandbox.config serialize workflows -f $(SERIALIZED_PB_OUTPUT_DIR)
+	pyflyte --config /home/nonroot/sandbox.config serialize workflows -f $(SERIALIZED_PB_OUTPUT_DIR)
 
 .PHONY: fast_serialize
 fast_serialize: $(SERIALIZED_PB_OUTPUT_DIR)
-	pyflyte --config /root/sandbox.config serialize fast workflows -f $(SERIALIZED_PB_OUTPUT_DIR)
+	pyflyte --config /home/nonroot/sandbox.config serialize fast workflows -f $(SERIALIZED_PB_OUTPUT_DIR)

--- a/cookbook/in_container.mk
+++ b/cookbook/in_container.mk
@@ -9,9 +9,9 @@ $(SERIALIZED_PB_OUTPUT_DIR): clean
 
 .PHONY: serialize
 serialize: $(SERIALIZED_PB_OUTPUT_DIR)
-	pyflyte --config /root/sandbox.config serialize workflows -f $(SERIALIZED_PB_OUTPUT_DIR)
+	pyflyte --config /home/nonroot/sandbox.config serialize workflows -f $(SERIALIZED_PB_OUTPUT_DIR)
 
 
 .PHONY: fast_serialize
 fast_serialize: $(SERIALIZED_PB_OUTPUT_DIR)
-	pyflyte --config /root/sandbox.config serialize fast workflows -f $(SERIALIZED_PB_OUTPUT_DIR)
+	pyflyte --config /home/nonroot/sandbox.config serialize fast workflows -f $(SERIALIZED_PB_OUTPUT_DIR)

--- a/cookbook/in_container.mk
+++ b/cookbook/in_container.mk
@@ -11,7 +11,6 @@ $(SERIALIZED_PB_OUTPUT_DIR): clean
 serialize: $(SERIALIZED_PB_OUTPUT_DIR)
 	pyflyte --config /home/nonroot/sandbox.config serialize workflows -f $(SERIALIZED_PB_OUTPUT_DIR)
 
-
 .PHONY: fast_serialize
 fast_serialize: $(SERIALIZED_PB_OUTPUT_DIR)
 	pyflyte --config /home/nonroot/sandbox.config serialize fast workflows -f $(SERIALIZED_PB_OUTPUT_DIR)


### PR DESCRIPTION
Currently all the flytesnacks containers are run as root. This PR builds flytesnacks containers to use a new nonroot user.