### PR TITLE
Add call to build extra images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ shell: _requires-sandbox-up  ## Drop into a development shell
 .PHONY: register
 register: _requires-sandbox-up  ## Register Flyte cookbook workflows
 	$(call LOG,Registering example workflows in cookbook/$(EXAMPLES_MODULE))
+	$(call RUN_IN_SANDBOX,make -C cookbook/$(EXAMPLES_MODULE) extra_images)
 	$(call RUN_IN_SANDBOX,make -C cookbook/$(EXAMPLES_MODULE) serialize)
 	make -C cookbook/$(EXAMPLES_MODULE) register
 

--- a/cookbook/common/common.mk
+++ b/cookbook/common/common.mk
@@ -37,3 +37,6 @@ setup: install-piptools # Install requirements
 .PHONY: lint
 lint:  # Run linters
 	flake8 .
+
+.PHONY: extra_images
+extra_images: ;

--- a/cookbook/core/Makefile
+++ b/cookbook/core/Makefile
@@ -2,3 +2,7 @@ PREFIX=core
 PWD=$(shell pwd)
 include ../common/common.mk
 include ../common/leaf.mk
+
+.PHONY: extra_images
+extra_images:
+	make -C containerization/raw-containers-supporting-files build_images


### PR DESCRIPTION
The raw containers example depends on a bunch of ad-hoc images defined in a separate [make file](https://github.com/flyteorg/flytesnacks/tree/master/cookbook/core/containerization/raw-containers-supporting-files). 

This PR adds an empty make target to `common.mk`, which is overridden in the case of `core` to build the raw container images during registration. 

One curiosity of this approach: `make` does not allow duplicated targets, which means that we get a harmless warning in the case of registering the `core` examples informing us that the `extra_images` target defined in `common.mk` is being clobbered:
```
../common/common.mk:42: warning: ignoring old recipe for target 'extra_images'
``` 

This fixes https://github.com/flyteorg/flyte/issues/1937.


Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>