### PR TITLE
update main section TOC card styles

### DIFF
--- a/cookbook/deployment/README.rst
+++ b/cookbook/deployment/README.rst
@@ -1,7 +1,7 @@
 .. _deployment_workflow:
 
-Workflow Deployment
--------------------
+Production Config
+-----------------
 
 Once you've finished iterating on your tasks and workflows locally, you can serialize and register them to a Flyte
 backend. This section covers how to configure and deploy your workflows for your particular needs.

--- a/cookbook/docs/feature_engineering.rst
+++ b/cookbook/docs/feature_engineering.rst
@@ -9,6 +9,7 @@ It is the process of transforming raw data into features that better represent t
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: auto/case_studies/feature_engineering/eda/index
        :type: ref

--- a/cookbook/docs/index.rst
+++ b/cookbook/docs/index.rst
@@ -145,6 +145,7 @@ Table of Contents
 
 .. panels::
    :header: text-center
+   :column: col-lg-12 p-2
 
    .. link-button:: auto/core/flyte_basics/index
       :type: ref
@@ -202,7 +203,7 @@ Table of Contents
 
    .. link-button:: auto/deployment/index
       :type: ref
-      :text: 🚢  Configuring Production Features
+      :text: 🚢  Production Config
       :classes: btn-block stretched-link
    ^^^^^^^^^^
    Ship and configure your machine learning pipelines on a production Flyte installation.
@@ -258,7 +259,7 @@ Table of Contents
    Testing <auto/testing/index>
    Containerization <auto/core/containerization/index>
    Remote Access <auto/remote_access/index>
-   Configuring Production Features <auto/deployment/index>
+   Production Config <auto/deployment/index>
    Scheduling Workflows <auto/core/scheduled_workflows/index>
    integrations
    Extending flyte <auto/core/extend_flyte/index>

--- a/cookbook/docs/integrations.rst
+++ b/cookbook/docs/integrations.rst
@@ -15,6 +15,7 @@ Flytekit functionality. These plugins can be anything and for comparison can be 
 
 .. panels::
    :header: text-center
+   :column: col-lg-12 p-2
 
    .. link-button:: auto/integrations/flytekit_plugins/sql/index
       :type: ref
@@ -82,6 +83,7 @@ orchestrated by Flyte itself, within its provisioned kubernetes clusters.
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: auto/integrations/kubernetes/pod/index
        :type: ref
@@ -139,6 +141,7 @@ the Flyte task that use the respective plugin.
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: auto/integrations/aws/sagemaker_training/index
        :type: ref
@@ -212,6 +215,7 @@ Because Flyte uses executable docker containers as the smallest unit of compute,
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: raw_container
        :type: ref
@@ -229,6 +233,7 @@ The :ref:`community <community>` would love to help you with your own ideas of b
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: https://flytekit.readthedocs.io
        :type: url

--- a/cookbook/docs/ml_training.rst
+++ b/cookbook/docs/ml_training.rst
@@ -4,6 +4,7 @@ ML Training
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: auto/case_studies/ml_training/pima_diabetes/index
        :type: ref

--- a/cookbook/docs/tutorials.rst
+++ b/cookbook/docs/tutorials.rst
@@ -14,6 +14,7 @@ documenting and contributing samples easy. If this is your first time running th
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: ml_training
        :type: ref


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

fixes https://github.com/flyteorg/flyte/issues/2013

These three PRs together will update the main section TOC card styles

https://github.com/flyteorg/flyte/pull/2027
https://github.com/flyteorg/flytesnacks/pull/575
https://github.com/flyteorg/furo/pull/9

Once these changes are merged the TOC cards should look like:

![image](https://user-images.githubusercontent.com/2816689/148435495-d43b11e6-9a2a-4945-8178-8035b6512613.png)
