### PR TITLE
Moving panel-and-toc image to static-resources repo and updating the url

### DIFF
--- a/cookbook/docs/contribute.rst
+++ b/cookbook/docs/contribute.rst
@@ -77,7 +77,7 @@ The ``docs`` folder in ``flytesnacks`` houses the required documentation configu
 
 4. Add the code for panel and TOC in the required RST file.
 
-     .. image:: https://github.com/flyteorg/static-resources/raw/main/flytesnacks/contribution-guide/panel_and_toc.png
+     .. image:: https://raw.githubusercontent.com/flyteorg/static-resources/main/flytesnacks/contribution-guide/panel_and_toc.png
          :alt: panel and TOC
 
 5. Add the name and path to ``.github/workflows/ghcr_push.yml`` if you're adding an integration or a tutorial.

--- a/cookbook/docs/contribute.rst
+++ b/cookbook/docs/contribute.rst
@@ -77,7 +77,7 @@ The ``docs`` folder in ``flytesnacks`` houses the required documentation configu
 
 4. Add the code for panel and TOC in the required RST file.
 
-     .. image:: https://user-images.githubusercontent.com/27777173/155274419-790f0916-7de0-4abf-9bd0-68c0b52859d3.png
+     .. image:: https://github.com/flyteorg/static-resources/raw/main/flytesnacks/contribution-guide/panel_and_toc.png
          :alt: panel and TOC
 
 5. Add the name and path to ``.github/workflows/ghcr_push.yml`` if you're adding an integration or a tutorial.


### PR DESCRIPTION
Since we have a new repo for all static-resources, I moved the panel and toc image and updated the URL here.

Signed-off-by: Alekhya Sai Punnamaraju <alekhyasaip@gmail.com>

Related issue: https://github.com/flyteorg/flyte/issues/1986