### PR TITLE
Move rawcontainers supporting images to ghcr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ shell: _requires-sandbox-up  ## Drop into a development shell
 .PHONY: register
 register: _requires-sandbox-up  ## Register Flyte cookbook workflows
 	$(call LOG,Registering example workflows in cookbook/$(EXAMPLES_MODULE))
-	$(call RUN_IN_SANDBOX,make -C cookbook/$(EXAMPLES_MODULE) extra_images)
 	$(call RUN_IN_SANDBOX,make -C cookbook/$(EXAMPLES_MODULE) serialize)
 	make -C cookbook/$(EXAMPLES_MODULE) register
 

--- a/cookbook/common/common.mk
+++ b/cookbook/common/common.mk
@@ -37,6 +37,3 @@ setup: install-piptools # Install requirements
 .PHONY: lint
 lint:  # Run linters
 	flake8 .
-
-.PHONY: extra_images
-extra_images: ;

--- a/cookbook/core/Makefile
+++ b/cookbook/core/Makefile
@@ -2,7 +2,3 @@ PREFIX=core
 PWD=$(shell pwd)
 include ../common/common.mk
 include ../common/leaf.mk
-
-.PHONY: extra_images
-extra_images:
-	make -C containerization/raw-containers-supporting-files build_images

--- a/cookbook/core/containerization/raw-containers-supporting-files/README.md
+++ b/cookbook/core/containerization/raw-containers-supporting-files/README.md
@@ -1,3 +1,5 @@
 # raw-containers-demo
 
 This directory holds the Dockerfiles and supporting files needed to run the example described in `raw_container.py`, split by language.
+
+The actual example points to images present in the gihub registry (i.e. ghcr.io), so in case we need to update the examples for any reason we should keep in mind to push them to ghcr too.

--- a/cookbook/core/containerization/raw_container.py
+++ b/cookbook/core/containerization/raw_container.py
@@ -81,7 +81,7 @@ calculate_ellipse_area_haskell = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="rawcontainers-haskell:v1",
+    image="ghcr.io/flyteorg/rawcontainers-haskell:v1",
     command=[
         "./calculate-ellipse-area",
         "/var/inputs",

--- a/cookbook/core/containerization/raw_container.py
+++ b/cookbook/core/containerization/raw_container.py
@@ -36,7 +36,7 @@ calculate_ellipse_area_shell = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="rawcontainers-shell:v1",
+    image="ghcr.io/flyteor/rawcontainers-shell:v1",
     command=[
         "./calculate-ellipse-area.sh",
         "/var/inputs",
@@ -50,7 +50,7 @@ calculate_ellipse_area_python = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="rawcontainers-python:v1",
+    image="ghcr.io/flyteor/rawcontainers-python:v1",
     command=[
         "python",
         "calculate-ellipse-area.py",
@@ -65,7 +65,7 @@ calculate_ellipse_area_r = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="rawcontainers-r:v1",
+    image="ghcr.io/flyteor/grawcontainers-r:v1",
     command=[
         "Rscript",
         "--vanilla",
@@ -95,7 +95,7 @@ calculate_ellipse_area_julia = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="rawcontainers-julia:v1",
+    image="ghcr.io/flyteor/rawcontainers-julia:v1",
     command=[
         "julia",
         "calculate-ellipse-area.jl",

--- a/cookbook/core/containerization/raw_container.py
+++ b/cookbook/core/containerization/raw_container.py
@@ -36,7 +36,7 @@ calculate_ellipse_area_shell = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteor/rawcontainers-shell:v1",
+    image="ghcr.io/flyteorg/rawcontainers-shell:v1",
     command=[
         "./calculate-ellipse-area.sh",
         "/var/inputs",
@@ -50,7 +50,7 @@ calculate_ellipse_area_python = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteor/rawcontainers-python:v1",
+    image="ghcr.io/flyteorg/rawcontainers-python:v1",
     command=[
         "python",
         "calculate-ellipse-area.py",
@@ -65,7 +65,7 @@ calculate_ellipse_area_r = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteor/grawcontainers-r:v1",
+    image="ghcr.io/flyteorg/rawcontainers-r:v1",
     command=[
         "Rscript",
         "--vanilla",
@@ -95,7 +95,7 @@ calculate_ellipse_area_julia = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteor/rawcontainers-julia:v1",
+    image="ghcr.io/flyteorg/rawcontainers-julia:v1",
     command=[
         "julia",
         "calculate-ellipse-area.jl",


### PR DESCRIPTION
This PR removes the logic used to build extra images, including the ones used in the raw containers example. Instead, since those images rarely change (in fact they never changed), we're going to store them directly in ghcr. 

By not building these images we see an improvement in the initial registration time of 4-5x of the `core` examples.