### PR TITLE
__init__.py in cookbook is not required

### DIFF
--- a/cookbook/.gitignore
+++ b/cookbook/.gitignore
@@ -13,3 +13,4 @@ docs/auto/*
 docs/_rsts/
 .hypothesis
 .config/
+test.ipynb


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>