### PR TITLE
Fix reference task

### DIFF
--- a/cookbook/core/flyte_basics/reference_task.py
+++ b/cookbook/core/flyte_basics/reference_task.py
@@ -14,8 +14,10 @@ This example demonstrates the usage of reference tasks.
 
 # %%
 # First, let's import the dependencies.
+from typing import List
+
 from flytekit import reference_task, workflow
-from flytekit.types.file import JPEGImageFile
+from flytekit.types.file import FlyteFile
 
 
 # %%
@@ -26,7 +28,12 @@ from flytekit.types.file import JPEGImageFile
     name="core.flyte_basics.files.rotate",
     version="{{ registration.version }}",
 )
-def rotate(image_location: JPEGImageFile, location: str) -> JPEGImageFile:
+def normalize_columns(
+    csv_url: FlyteFile,
+    column_names: List[str],
+    columns_to_normalize: List[str],
+    output_location: str,
+) -> FlyteFile:
     ...
 
 
@@ -46,16 +53,18 @@ def rotate(image_location: JPEGImageFile, location: str) -> JPEGImageFile:
 #               name="core.flyte_basics.files.rotate",
 #               version="d06cebcfbeabc02b545eefa13a01c6ca992940c8", # If using GIT for versioning OR 0.16.0, if semver
 #           )
-#           def rotate(...):
+#           def normalize_columns(...):
 #               ...
 
 # %%
 # Next, we define a workflow to call the ``rotate()`` task.
 @workflow
-def wf():
-    return rotate(
-        image_location="https://upload.wikimedia.org/wikipedia/commons/d/d2/Julia_set_%28C_%3D_0.285%2C_0.01%29.jpg",
-        location= ""
+def wf() -> FlyteFile:
+    return normalize_columns(
+        csv_url="https://people.sc.fsu.edu/~jburkardt/data/csv/biostats.csv",
+        column_names=["Name", "Sex", "Age", "Heights (in)", "Weight (lbs)"],
+        columns_to_normalize=["Age"],
+        output_location="",
     )
 
 

--- a/cookbook/core/flyte_basics/reference_task.py
+++ b/cookbook/core/flyte_basics/reference_task.py
@@ -25,7 +25,7 @@ from flytekit.types.file import FlyteFile
 @reference_task(
     project="flytesnacks",
     domain="development",
-    name="core.flyte_basics.files.rotate",
+    name="core.flyte_basics.files.normalize_columns",
     version="{{ registration.version }}",
 )
 def normalize_columns(

--- a/cookbook/core/flyte_basics/reference_task.py
+++ b/cookbook/core/flyte_basics/reference_task.py
@@ -50,7 +50,7 @@ def normalize_columns(
 #          @reference_task(
 #               project="flytesnacks",
 #               domain="development",
-#               name="core.flyte_basics.files.rotate",
+#               name="core.flyte_basics.files.normalize_columns",
 #               version="d06cebcfbeabc02b545eefa13a01c6ca992940c8", # If using GIT for versioning OR 0.16.0, if semver
 #           )
 #           def normalize_columns(...):


### PR DESCRIPTION
This PR replaces the last use of the `rotate` function removed in https://github.com/flyteorg/flytesnacks/pull/715.