### PR TITLE
pyflyte run cmd scripts and tests

### DIFF
--- a/cookbook/core/flyte_basics/basic_workflow.py
+++ b/cookbook/core/flyte_basics/basic_workflow.py
@@ -75,3 +75,20 @@ if __name__ == "__main__":
 
 # %%
 # To know more about workflows, take a look at the conceptual :std:ref:`discussion <flyte:divedeep-workflow-nodes>`.
+
+
+# %%
+#
+# .. dropdown:: :fa:`play` Run this example
+#
+#    Assuming you have your :ref:`development environment <env_setup>` ready:
+#
+#    .. tabbed:: pyflyte run
+#
+#       .. literalinclude:: /../core/flyte_basics/tests/test_basic_workflow.sh
+#          :language: bash
+#
+#    .. tabbed:: Python API
+#
+#       .. literalinclude:: /../core/flyte_basics/tests/test_basic_workflow.py
+#          :language: python

--- a/cookbook/core/flyte_basics/basic_workflow.py
+++ b/cookbook/core/flyte_basics/basic_workflow.py
@@ -78,17 +78,4 @@ if __name__ == "__main__":
 
 
 # %%
-#
-# .. dropdown:: :fa:`play` Run this example
-#
-#    Assuming you have your :ref:`development environment <env_setup>` ready:
-#
-#    .. tabbed:: pyflyte run
-#
-#       .. literalinclude:: /../core/flyte_basics/tests/test_basic_workflow.sh
-#          :language: bash
-#
-#    .. tabbed:: Python API
-#
-#       .. literalinclude:: /../core/flyte_basics/tests/test_basic_workflow.py
-#          :language: python
+# .. run-example-cmds::

--- a/cookbook/core/flyte_basics/hello_world.py
+++ b/cookbook/core/flyte_basics/hello_world.py
@@ -1,4 +1,5 @@
 """
+
 Hello World
 ------------
 This simple workflow calls a task that returns "Hello World" and then just sets that as the final output of the workflow.

--- a/cookbook/core/flyte_basics/imperative_wf_style.py
+++ b/cookbook/core/flyte_basics/imperative_wf_style.py
@@ -42,35 +42,35 @@ def t3(a: typing.List[str]) -> str:
 
 # %%
 # Start by creating an imperative style workflow, which is aliased to just ``Workflow`` from ``flytekit``
-wb = Workflow(name="my.imperative.workflow.example")
+wf = Workflow(name="my.imperative.workflow.example")
 
 
 # %%
 # Inputs have to be added to the workflow before they can be used. Add them by specifying the name and the type.
-wb.add_workflow_input("in1", str)
+wf.add_workflow_input("in1", str)
 
 # %%
 # Next associate a task, and pass in the workflow level input.
-node_t1 = wb.add_entity(t1, a=wb.inputs["in1"])
+node_t1 = wf.add_entity(t1, a=wf.inputs["in1"])
 
 # %%
 # Create a workflow output linked to the output of that task.
-wb.add_workflow_output("output_from_t1", node_t1.outputs["o0"])
+wf.add_workflow_output("output_from_t1", node_t1.outputs["o0"])
 
 # %%
 # To add a task that has no inputs or outputs, just add the entity. We don't need to capture the resulting node
 # because we have no use for it.
-wb.add_entity(t2)
+wf.add_entity(t2)
 
 # %%
 # We can also pass in a list to a task. Also creating a workflow input returns an object that can be used as an
 # alternate way of linking workflow inputs. Here, ``t3`` uses both workflow inputs.
-wf_in2 = wb.add_workflow_input("in2", str)
-node_t3 = wb.add_entity(t3, a=[wb.inputs["in1"], wf_in2])
+wf_in2 = wf.add_workflow_input("in2", str)
+node_t3 = wf.add_entity(t3, a=[wf.inputs["in1"], wf_in2])
 
 # %%
 # You can also create a workflow input as a list from multiple task outputs
-wb.add_workflow_output(
+wf.add_workflow_output(
     "output_list",
     [node_t1.outputs["o0"], node_t3.outputs["o0"]],
     python_type=typing.List[str],
@@ -78,5 +78,5 @@ wb.add_workflow_output(
 
 
 if __name__ == "__main__":
-    print(wb)
-    print(wb(in1="hello", in2="foo"))
+    print(wf)
+    print(wf(in1="hello", in2="foo"))

--- a/cookbook/core/flyte_basics/task.py
+++ b/cookbook/core/flyte_basics/task.py
@@ -58,12 +58,29 @@ if __name__ == "__main__":
     print(square(n=10))
 
 # %%
+#
+# Invoke a Task within a Workflow
+# ===============================
+#
+# The primary way to use Flyte tasks is to invoke them in the context of a workflow.
+
+from flytekit import workflow
+
+
+@workflow
+def wf(n: int) -> int:
+    return square(n=square(n=n))
+
+# %%
+# In this toy example, we're calling the ``square`` task twice and returning the reult.
+
+
+# %%
 # .. _single_task_execution:
 #
 # Single Task Execution
 # =====================
 #
-# Tasks are the atomic units of execution in Flyte.
 # Although workflows are traditionally composed of multiple tasks with dependencies defined by shared inputs and outputs,
 # it can be helpful to execute a single task during the process of iterating on its definition.
 # It can be tedious to write a new workflow definition every time you want to execute a single task under development

--- a/cookbook/core/flyte_basics/tests/test_basic_workflow.py
+++ b/cookbook/core/flyte_basics/tests/test_basic_workflow.py
@@ -1,0 +1,20 @@
+from flytekit.configuration import Config
+from flytekit.remote import FlyteRemote
+from flytekit.tools.translator import Options
+
+from core.extend_flyte.run_custom_types import wf
+
+remote = FlyteRemote(
+    config=Config.for_endpoint("localhost:30080"),
+    default_project="flytesnacks",
+    default_domain="development",
+)
+
+registered_workflow = remote.register_script(
+    wf, options=Options.default_from(k8s_service_account="demo")
+)
+
+remote.execute(
+    registered_workflow,
+    inputs={},
+)

--- a/cookbook/core/flyte_basics/tests/test_basic_workflow.py
+++ b/cookbook/core/flyte_basics/tests/test_basic_workflow.py
@@ -1,20 +1,15 @@
 from flytekit.configuration import Config
 from flytekit.remote import FlyteRemote
-from flytekit.tools.translator import Options
 
-from core.extend_flyte.run_custom_types import wf
+from basic_workflow import my_wf
 
 remote = FlyteRemote(
-    config=Config.for_endpoint("localhost:30080"),
+    config=Config.for_endpoint("localhost:30081", insecure=True),
     default_project="flytesnacks",
     default_domain="development",
 )
 
-registered_workflow = remote.register_script(
-    wf, options=Options.default_from(k8s_service_account="demo")
-)
+registered_workflow = remote.register_script(my_wf)
 
-remote.execute(
-    registered_workflow,
-    inputs={},
-)
+execution = remote.execute(registered_workflow, inputs={"a": 100, "b": "hello"})
+print(f"Execution successfully started: {execution}")

--- a/cookbook/core/flyte_basics/tests/test_basic_workflow.sh
+++ b/cookbook/core/flyte_basics/tests/test_basic_workflow.sh
@@ -1,0 +1,1 @@
+pyflyte run --remote basic_workflow.py:my_wf --a 100 --b hello

--- a/cookbook/core/flyte_basics/tests/test_hello_world.py
+++ b/cookbook/core/flyte_basics/tests/test_hello_world.py
@@ -1,7 +1,7 @@
 from flytekit.configuration import Config
 from flytekit.remote import FlyteRemote
 
-from basic_workflow import my_wf
+from hello_world import my_wf
 
 remote = FlyteRemote(
     config=Config.for_endpoint("localhost:30081", insecure=True),
@@ -11,5 +11,5 @@ remote = FlyteRemote(
 
 registered_workflow = remote.register_script(my_wf)
 
-execution = remote.execute(registered_workflow, inputs={"a": 100, "b": "hello"})
+execution = remote.execute(registered_workflow, inputs={})
 print(f"Execution successfully started: {execution.id.name}")

--- a/cookbook/core/flyte_basics/tests/test_hello_world.sh
+++ b/cookbook/core/flyte_basics/tests/test_hello_world.sh
@@ -1,0 +1,1 @@
+pyflyte run --remote hello_world.py:my_wf

--- a/cookbook/core/flyte_basics/tests/test_imperative_wf_style.py
+++ b/cookbook/core/flyte_basics/tests/test_imperative_wf_style.py
@@ -1,7 +1,7 @@
 from flytekit.configuration import Config
 from flytekit.remote import FlyteRemote
 
-from basic_workflow import my_wf
+from imperative_wf_style import wf
 
 remote = FlyteRemote(
     config=Config.for_endpoint("localhost:30081", insecure=True),
@@ -9,7 +9,7 @@ remote = FlyteRemote(
     default_domain="development",
 )
 
-registered_workflow = remote.register_script(my_wf)
+registered_workflow = remote.register_script(wf)
 
-execution = remote.execute(registered_workflow, inputs={"a": 100, "b": "hello"})
+execution = remote.execute(registered_workflow, inputs={"in1": "hello", "in2": "foo"})
 print(f"Execution successfully started: {execution.id.name}")

--- a/cookbook/core/flyte_basics/tests/test_imperative_wf_style.sh
+++ b/cookbook/core/flyte_basics/tests/test_imperative_wf_style.sh
@@ -1,0 +1,1 @@
+pyflyte run --remote imperative_wf_style.py:wf --in1 hello --in2 foo

--- a/cookbook/core/flyte_basics/tests/test_task.py
+++ b/cookbook/core/flyte_basics/tests/test_task.py
@@ -1,7 +1,7 @@
 from flytekit.configuration import Config
 from flytekit.remote import FlyteRemote
 
-from basic_workflow import my_wf
+from task import wf
 
 remote = FlyteRemote(
     config=Config.for_endpoint("localhost:30081", insecure=True),
@@ -9,7 +9,7 @@ remote = FlyteRemote(
     default_domain="development",
 )
 
-registered_workflow = remote.register_script(my_wf)
+registered_workflow = remote.register_script(wf)
 
-execution = remote.execute(registered_workflow, inputs={"a": 100, "b": "hello"})
+execution = remote.execute(registered_workflow, inputs={"n": 2})
 print(f"Execution successfully started: {execution.id.name}")

--- a/cookbook/core/flyte_basics/tests/test_task.sh
+++ b/cookbook/core/flyte_basics/tests/test_task.sh
@@ -1,0 +1,1 @@
+pyflyte run --remote task.py:wf --n 2

--- a/cookbook/dev-requirements.in
+++ b/cookbook/dev-requirements.in
@@ -19,3 +19,4 @@ flake8-isort
 isort
 mock
 pytest
+pytest-xdist[psutil]

--- a/cookbook/docs/_ext/run_example_cmds_extension.py
+++ b/cookbook/docs/_ext/run_example_cmds_extension.py
@@ -1,0 +1,81 @@
+import inspect
+from pathlib import Path
+from typing import NamedTuple
+
+from docutils import nodes
+from docutils.statemachine import StringList, string2lines
+from sphinx.util.docutils import SphinxDirective
+
+
+TEMPLATE = """
+.. dropdown:: :fa:`play` Run this example
+
+   Assuming you have your :ref:`development environment <env_setup>` ready:
+
+   .. prompt:: bash
+
+      cd cookbook/{example_root_dir}
+   
+   .. tabbed:: pyflyte run
+
+      In a terminal session, run:
+
+      .. literalinclude:: /../{pyflyte_run_path}
+         :language: bash
+
+   .. tabbed:: FlyteRemote API
+
+      Execute the following code in a python session or jupyter notebook:
+
+      .. literalinclude:: /../{flyte_remote_path}
+         :language: python
+
+"""
+
+
+TestScriptPaths = NamedTuple(
+    "TestScriptPaths",
+    [
+        ("example_root_dir", str),
+        ("pyflyte_run_path", str),
+        ("flyte_remote_path", str),
+    ]
+)
+
+
+class RunExampleCmds(SphinxDirective):
+    has_content = True
+
+    def run(self) -> list:
+        return [self.parse_rst_template()]
+
+    def get_test_script_paths(self) -> TestScriptPaths:
+        full_source_path = self.get_source_info()[0]
+        rel_path = Path(full_source_path.split("/auto/")[-1])
+        test_dir = rel_path.parent / "tests"
+        return TestScriptPaths(
+            str(rel_path.parent),
+            str(test_dir / f"test_{rel_path.stem}.sh"),
+            str(test_dir / f"test_{rel_path.stem}.py"),
+        )
+    
+    def parse_rst_template(self):
+        """Parse rst template for run commands into docutils nodes.
+        
+        This was adapted from this example: https://www.bustawin.com/sphinx-extension-devel/
+        """
+        test_script_paths = self.get_test_script_paths()
+        container = nodes.container("")
+        template = inspect.cleandoc(
+            TEMPLATE.format(
+                example_root_dir=test_script_paths.example_root_dir,
+                pyflyte_run_path=test_script_paths.pyflyte_run_path,
+                flyte_remote_path=test_script_paths.flyte_remote_path,
+            )
+        )
+        self.state.nested_parse(StringList(string2lines(template)), 0, container)
+        return container
+
+
+def setup(app: object) -> dict:
+    app.add_directive("run-example-cmds", RunExampleCmds)

--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -20,6 +20,7 @@ from sphinx.errors import ConfigError
 from sphinx_gallery.sorting import FileNameSortKey
 
 sys.path.insert(0, os.path.abspath("../"))
+sys.path.append(os.path.abspath("./_ext"))
 
 # -- Project information -----------------------------------------------------
 
@@ -195,6 +196,7 @@ extensions = [
     "sphinxcontrib.mermaid",
     "sphinxcontrib.yt",
     "sphinx_tabs.tabs",
+    "run_example_cmds_extension",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -339,15 +339,16 @@ min_reported_time = 0
 
 # hide example pages with empty content
 ignore_py_files = [
-    "__init__",
-    "config_resource_mgr",
-    "optimize_perf",
+    "__init__\.py",
+    "config_resource_mgr\.py",
+    "optimize_perf\.py",
+    "^test_.+\.py",
 ]
 
 sphinx_gallery_conf = {
     "examples_dirs": examples_dirs,
     "gallery_dirs": gallery_dirs,
-    "ignore_pattern": f"({'|'.join(ignore_py_files)})\.py",
+    "ignore_pattern": f"{'|'.join(ignore_py_files)}",
     # "subsection_order": ExplicitOrder(
     #     [
     #         "../core/basic",

--- a/cookbook/tests/integration/test_run_examples.py
+++ b/cookbook/tests/integration/test_run_examples.py
@@ -1,0 +1,105 @@
+import re
+import subprocess
+import time
+import typing
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from flytekit.configuration import Config
+from flytekit.remote import FlyteRemote
+
+
+N_SYNCS = 200
+
+
+COOKBOOK_ROOT_DIR = Path(__file__).parent / ".." / ".."
+
+
+
+@dataclass
+class ExampleTestCase:
+    script_rel_path: Path
+    expected_output: typing.Any
+    root_dir: Path = field(init=False)
+    pyflyte_run_args: typing.List[str] = field(init=False)
+    flytekit_remote_args: typing.List[str] = field(init=False)
+
+    def __post_init__(self):
+        full_path = COOKBOOK_ROOT_DIR / self.script_rel_path
+        self.root_dir = full_path.parent
+        self.pyflyte_run_args = ["bash", f"tests/test_{full_path.stem}.sh"]
+        self.flytekit_remote_args = ["python", "-m", f"tests.test_{full_path.stem}"]
+
+
+@pytest.fixture(scope="session")
+def flyte_remote():
+
+    p_status = subprocess.run(["flytectl", "demo", "status"], capture_output=True)
+
+    cluster_preexists = True
+    if p_status.stdout.decode().strip() == "🛑 no demo cluster found":
+        # if a demo cluster didn't exist already, then start one.
+        cluster_preexists = False
+        subprocess.run(["flytectl", "demo", "start"])
+
+    remote = FlyteRemote(
+        config=Config.for_endpoint("localhost:30081", insecure=True),
+        default_project="flytesnacks",
+        default_domain="development",
+    )
+    projects, *_ = remote.client.list_projects_paginated(limit=5, token=None)
+    assert projects[0].id == "flytesnacks"
+    assert projects[0].name == "flytesnacks"
+
+    yield remote
+
+    if not cluster_preexists:
+        # only teardown the demo cluster if it didn't preexist
+        subprocess.run(["flytectl", "demo", "teardown"])
+
+
+def get_execution(flyte_remote, execution_name):
+    execution = flyte_remote.fetch_execution(name=execution_name)
+    flyte_remote.wait(execution, sync_nodes=False)
+    return flyte_remote.sync_execution(execution)
+
+
+def get_execution_name_pyflyte(x):
+    """
+    Get the execution name from pyflyte run stdout, e.g.:
+
+    "Go to localhost:30081/console/.../executions/asdf1234" -> "asdf1234"
+    """
+    return re.match(r".+\/executions\/(\S+) .+", x).group(1)
+
+
+def get_execution_name_flytekit_remote(x):
+    """
+    Get the execution name from FlyteRemote python script example, e.g.:
+
+    "Execution successfully started: asdf1234" -> "asdf1234"
+    """
+    return re.match(r".+: (\S+)$", x).group(1)
+
+
+@pytest.mark.parametrize(
+    "example_test_case", [
+        ExampleTestCase("core/flyte_basics/hello_world.py", {"o0": "hello world"}),
+        ExampleTestCase("core/flyte_basics/task.py", {"o0": 16}),
+        ExampleTestCase("core/flyte_basics/basic_workflow.py", {"o0": 102, "o1": "helloworld"}),
+    ],
+)
+@pytest.mark.parametrize("run_type", ["pyflyte_run", "flytekit_remote"])
+def test_example_suite(flyte_remote: FlyteRemote, example_test_case: ExampleTestCase, run_type: str):
+    args = example_test_case.pyflyte_run_args
+    get_execution_name = get_execution_name_pyflyte
+    if run_type == "flytekit_remote":
+        args = example_test_case.flytekit_remote_args
+        get_execution_name = get_execution_name_flytekit_remote
+
+    pyflyte_run_proc = subprocess.run(args, cwd=example_test_case.root_dir, capture_output=True)
+    execution_name = get_execution_name(pyflyte_run_proc.stdout.decode().strip())
+    execution = get_execution(flyte_remote, execution_name)
+    assert execution.outputs == example_test_case.expected_output


### PR DESCRIPTION
This PR:
- adds test scripts for some of the core flyte example
- creates an integration test harness for executing test scripts against a demo flyte cluster
- create a custom sphinx directive that adds the test script code to the bottom of the flytesnacks examples