### PR TITLE
docs: Fix the invalid logging template example

### DIFF
--- a/cookbook/deployment/configure_logging_links.py
+++ b/cookbook/deployment/configure_logging_links.py
@@ -53,11 +53,12 @@ The parameterization engine uses Golangs native templating format and hence uses
   task_logs:
     plugins:
       logs:
-        displayName: <name-to-show>
-        templateUris:
-          - "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/flyte-production/kubernetes;stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
-          - "https://some-other-source/home?region=us-east-1#logEventViewer:group=/flyte-production/kubernetes;stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
-        messageFormat: "json" # "unknown" | "csv" | "json"
+        templates:
+          - displayName: <name-to-show>
+            templateUris:
+              - "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/flyte-production/kubernetes;stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
+              - "https://some-other-source/home?region=us-east-1#logEventViewer:group=/flyte-production/kubernetes;stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
+            messageFormat: "json" # "unknown" | "csv" | "json"
 
 This code snippet will output two logs per task that use the log plugin.
 However, not all task types use the log plugin; for example, the Sagemaker plugin uses the log output provided by Sagemaker, and the Snowflake plugin will use a link to the snowflake console.


### PR DESCRIPTION
Doc page: https://docs.flyte.org/projects/cookbook/en/latest/auto/deployment/configure_logging_links.html 

As per the https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/logs#LogConfig struct, templates should be under `templates` field

From the [build](https://flyte--738.org.readthedocs.build/projects/cookbook/en/738/auto/deployment/configure_logging_links.html#sphx-glr-auto-deployment-configure-logging-links-py) it looks as expected: 
<img width="858" alt="image" src="https://user-images.githubusercontent.com/6486584/164724320-bcef1cec-34c8-4f21-a617-07df11a05761.png">
