### PR TITLE
Add note to mention about chained subworkflows

### DIFF
--- a/cookbook/core/control_flow/subworkflows.py
+++ b/cookbook/core/control_flow/subworkflows.py
@@ -93,6 +93,9 @@ def nested_parent_wf(a: int) -> Tuple[int, str, str, str]:
 if __name__ == "__main__":
     print(f"Running nested_parent_wf(a=3) {nested_parent_wf(a=3)}")
 
+# %%
+# .. note:: You can chain and execute subworkflows similar to chained :ref:`Flyte tasks<Chain Flyte Tasks>`.
+
 
 # %%
 # External Workflow


### PR DESCRIPTION
[Issue #2475](https://github.com/flyteorg/flyte/issues/2475)
Add a note specifying that subworkflows can be chained similar to Flyte tasks
Signed-off-by: SmritiSatyanV <smriti@union.ai>