### PR TITLE
Fix deck example

### DIFF
--- a/cookbook/core/flyte_basics/deck.py
+++ b/cookbook/core/flyte_basics/deck.py
@@ -17,6 +17,7 @@ Let's dive into an example.
 
 # %%
 # Import the dependencies.
+import flytekit
 import pandas as pd
 import plotly.express as px
 from flytekit import task, workflow


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

Prior to this we were seeing this error in executions of this workflow:
```
Traceback (most recent call last):

      File "/opt/venv/lib/python3.8/site-packages/flytekit/exceptions/scopes.py", line 203, in user_entry_point
        return wrapped(*args, **kwargs)
      File "/root/core/flyte_basics/deck.py", line 37, in t1
        flytekit.Deck("demo", BoxRenderer("sepal_length").to_html(iris_df))

Message:

    name 'flytekit' is not defined

User error.
```

We're also going to enable this in the functional tests.