### PR TITLE
fixes header hierarchy in dynamic workflow page

### DIFF
--- a/cookbook/core/control_flow/dynamics.py
+++ b/cookbook/core/control_flow/dynamics.py
@@ -1,6 +1,7 @@
 """
+=================
 Dynamic Workflows
-------------------
+=================
 
 A workflow is typically static when the directed acyclic graph's (DAG) structure is known at compile-time.
 However, in cases where a run-time parameter (for example, the output of an earlier task) determines the full DAG structure, you can use dynamic workflows by decorating a function with ``@dynamic``.
@@ -141,8 +142,8 @@ if __name__ == "__main__":
 
 
 # %%
-# Dynamic Workflows from Execution POV
-# ------------------------------------
+# Dynamic Workflows Under the Hood
+# --------------------------------
 #
 # What Is a Dynamic Workflow?
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

The mis-specified header in the [dynamic workflows page](https://docs.flyte.org/projects/cookbook/en/latest/auto/core/control_flow/dynamics.html#dynamic-workflows) causes a header to show up in the sidebar
![image](https://user-images.githubusercontent.com/2816689/191328972-5ee32347-d121-4bfe-bf79-7d5402b94fe2.png)
