### PR TITLE
Update the note in dataclass example

### DIFF
--- a/cookbook/core/type_system/custom_objects.py
+++ b/cookbook/core/type_system/custom_objects.py
@@ -64,7 +64,8 @@ class Result:
 # %%
 # .. note::
 #
-#   A data class supports the usage of data associated with Python types, data classes, FlyteFile, FlyteDirectory, and FlyteSchema.
+#   1. A data class supports the usage of data associated with Python types, data classes, FlyteFile, FlyteDirectory, and FlyteSchema.
+#   2. We use the Marshmallow package to serialize the dataclass, and it doesn't support union type in the dataclass.
 #
 # Once declared, dataclasses can be returned as outputs or accepted as inputs.
 #


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

Added a note telling people that union types cannot be used in data classes.