### PR TITLE
Lift restrictions on cache overrides

### DIFF
--- a/cookbook/core/flyte_basics/task_cache.py
+++ b/cookbook/core/flyte_basics/task_cache.py
@@ -169,11 +169,6 @@ def wf_1(a: int, b: str):  # noqa: F811
 #
 # This feature also works in local execution.
 #
-# How to Enable Caching of Offloaded Types for a Different Type Transformer?
-# ***************************************************************************
-#
-# The ability to cache offloaded objects is controlled by the `hash_overridable <https://github.com/flyteorg/flytekit/blob/9754a0f462f495dbd77df0572719885230bd909b/flytekit/core/type_engine.py#L56-L62>`_ property of the Type Transformer. For example, see how this is done in the case of `StructuredDataSetTransformer <https://github.com/flyteorg/flytekit/blob/9754a0f462f495dbd77df0572719885230bd909b/flytekit/types/structured/structured_dataset.py#L382-L383>`_.
-
 # %%
 # Here's a complete example of the feature:
 
@@ -204,7 +199,7 @@ def compare_dataframes(df1: pandas.DataFrame, df2: pandas.DataFrame):
 def cached_dataframe_wf():
     raw_data = uncached_data_reading_task()
 
-    # Execute `cached_data_processing_task` twice, but we force those
+    # Execute `cached_data_processing_task` twice, but force those
     # two executions to happen serially to demonstrate how the second run
     # hits the cache.
     t1_node = create_node(cached_data_processing_task, df=raw_data)

--- a/cookbook/core/flyte_basics/task_cache.py
+++ b/cookbook/core/flyte_basics/task_cache.py
@@ -127,7 +127,7 @@ def wf(a: int, b: str):
 
 # %%
 # If run twice with the same inputs, one would expect that ``bar`` would trigger a cache hit, but it turns out that's not the case because of how dataframes are represented in Flyte.
-# However, with release 0.19.3, Flyte provides a new way to control memoization behavior of  `FlyteSchema` and `StructuredDataset` literals. This is done via a ``typing.Annotated`` call on the task signature.
+# However, with release 1.2.0, Flyte provides a new way to control memoization behavior of literals. This is done via a ``typing.Annotated`` call on the task signature.
 # For example, in order to cache the result of calls to ``bar``, you can rewrite the code above like this:
 
 


### PR DESCRIPTION
Related to https://github.com/flyteorg/flyte/issues/2912

With the [1.2.0](https://github.com/flyteorg/flytekit/pull/1171) we now let users override cache keys in the case of all types. This PR removes mentions to that restriction.