### PR TITLE
Add code snippets to remote access section

### DIFF
--- a/cookbook/remote_access/debugging_workflows_tasks.py
+++ b/cookbook/remote_access/debugging_workflows_tasks.py
@@ -25,42 +25,4 @@ The launched pods will have a prefix of execution name along with suffix of node
 
 So here the investigation can move ahead by describing the pod and checking the issue with Image pull.
 
-Using flytekit (python):
-========================
-For how to inspect an execution, go back to `Inspecting Workflow and Task Executions <https://docs.flyte.org/projects/cookbook/en/latest/auto/remote_access/inspecting_executions.html>`__
-
-More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
-
-.. code-block:: python
-        from flytekit.remote import FlyteRemote
-
-        # FlyteRemote object is the main entrypoint to API
-        remote = FlyteRemote(
-                config=Config.for_endpoint(endpoint="flyte.example.net"),
-                default_project="flytesnacks",
-                default_domain="development",
-        )
-        
-        # Fetch execution
-        execution = remote.fetch_execution(
-                name="fb22e306a0d91e1c6000", project="flytesnacks", domain="development"
-        )
-
-        # You can use FlyteRemote.sync() to to sync the entity object's state with the remote state during the execution run
-        synced_execution = remote.sync(execution, sync_nodes=True)
-        node_keys = synced_execution.node_executions.keys()
-
-During the sync, you may come across ``Received message larger than max (xxx vs. 4194304)`` error if the message size is too large. 
-
-In that case, edit the ``flyte-admin-base-config`` config map using the command ``kubectl edit cm flyte-admin-base-config -n flyte`` 
-to increase the ``maxMessageSizeBytes`` value. 
-
-Refer to the `troubleshooting guide <https://docs.flyte.org/en/latest/community/troubleshoot.html>` for more info.
-
-``node_executions`` will fetch all the underlying node executions recursively.
-
-To fetch output of a specific node execution:
-.. code-block:: python
-        node_execution_output = synced_execution.node_executions["n1"].outputs["model_file"]
-
 """

--- a/cookbook/remote_access/debugging_workflows_tasks.py
+++ b/cookbook/remote_access/debugging_workflows_tasks.py
@@ -25,4 +25,42 @@ The launched pods will have a prefix of execution name along with suffix of node
 
 So here the investigation can move ahead by describing the pod and checking the issue with Image pull.
 
+Using flytekit (python):
+========================
+For how to inspect an execution, go back to `Inspecting Workflow and Task Executions <https://docs.flyte.org/projects/cookbook/en/latest/auto/remote_access/inspecting_executions.html>`__
+
+More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
+
+.. code-block:: python
+        from flytekit.remote import FlyteRemote
+
+        # FlyteRemote object is the main entrypoint to API
+        remote = FlyteRemote(
+                config=Config.for_endpoint(endpoint="flyte.example.net"),
+                default_project="flytesnacks",
+                default_domain="development",
+        )
+        
+        # Fetch execution
+        execution = remote.fetch_execution(
+                name="fb22e306a0d91e1c6000", project="flytesnacks", domain="development"
+        )
+
+        # You can use FlyteRemote.sync() to to sync the entity object's state with the remote state during the execution run
+        synced_execution = remote.sync(execution, sync_nodes=True)
+        node_keys = synced_execution.node_executions.keys()
+
+During the sync, you may come across ``Received message larger than max (xxx vs. 4194304)`` error if the message size is too large. 
+
+In that case, edit the ``flyte-admin-base-config`` config map using the command ``kubectl edit cm flyte-admin-base-config -n flyte`` 
+to increase the ``maxMessageSizeBytes`` value. 
+
+Refer to the `troubleshooting guide <https://docs.flyte.org/en/latest/community/troubleshoot.html>` for more info.
+
+``node_executions`` will fetch all the underlying node executions recursively.
+
+To fetch output of a specific node execution:
+.. code-block:: python
+        node_execution_output = synced_execution.node_executions["n1"].outputs["model_file"]
+
 """

--- a/cookbook/remote_access/inspecting_executions.py
+++ b/cookbook/remote_access/inspecting_executions.py
@@ -2,6 +2,9 @@
 Inspecting Workflow and Task Executions
 ---------------------------------------
 
+Using flyctl:
+=============
+
 Inspecting workflow and task executions are done in the same manner as below. For more details see the
 `flytectl API reference <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_get_execution.html>`__.
 
@@ -20,5 +23,35 @@ If you prefer to see yaml/json view for the details then change the output forma
 To see the results of the execution you can inspect the node closure outputUri in detailed yaml output. ::
 
     "outputUri": "s3://my-s3-bucket/metadata/propeller/flytesnacks-development-<execid>/n0/data/0/outputs.pb"
+
+
+Using flytekit (python):
+========================
+More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
+
+.. code-block:: python
+    from flytekit.remote import FlyteRemote
+
+    # FlyteRemote object is the main entrypoint to API
+    remote = FlyteRemote(
+        config=Config.for_endpoint(endpoint="flyte.example.net"),
+        default_project="flytesnacks",
+        default_domain="development",
+    )
+    
+    execution = remote.fetch_execution(
+        name="fb22e306a0d91e1c6000", project="flytesnacks", domain="development"
+    )
+
+    # Inspecting execution
+    # The 'inputs' and 'outputs' correspond to the top-level execution or the workflow itself.
+    input_keys = execution.inputs.keys()
+    output_keys = execution.outputs.keys()
+
+    # Fetching a specific output, say, a model file:
+    model_file = execution.outputs["model_file"]
+    with open(model_file) as f:
+        # use mode
+        ...
 
 """

--- a/cookbook/remote_access/inspecting_executions.py
+++ b/cookbook/remote_access/inspecting_executions.py
@@ -2,8 +2,8 @@
 Inspecting Workflow and Task Executions
 ---------------------------------------
 
-Flytectl:
-=============
+Flytectl
+========
 
 Flytectl supports inspecting execution by retrieving its details. For a deeper dive, refer to the
 `API reference <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_get_execution.html>`__ guide.
@@ -25,10 +25,10 @@ To see the results of the execution you can inspect the node closure outputUri i
     "outputUri": "s3://my-s3-bucket/metadata/propeller/flytesnacks-development-<execid>/n0/data/0/outputs.pb"
 
 
-FlyteRemote:
-========================
+FlyteRemote
+===========
 
-With FlyteRemote, you can fetch the inputs and outputs of execution and inspect them.
+With FlyteRemote, you can fetch the inputs and outputs of executions and inspect them.
 
 .. code-block:: python
 
@@ -45,13 +45,21 @@ With FlyteRemote, you can fetch the inputs and outputs of execution and inspect 
         name="fb22e306a0d91e1c6000", project="flytesnacks", domain="development"
     )
 
-    # Inspecting execution
-    # The 'inputs' and 'outputs' correspond to the top-level execution or the workflow itself.
     input_keys = execution.inputs.keys()
     output_keys = execution.outputs.keys()
 
-    # You can use FlyteRemote.sync() to to sync the entity object's state with the remote state during the execution run
+    # The inputs and outputs correspond to the top-level execution or the workflow itself.
+    # To fetch a specific output, say, a model file:
+    model_file = execution.outputs["model_file"]
+    with open(model_file) as f:
+        ...
+
+    # You can use FlyteRemote.sync() to sync the entity object's state with the remote state during the execution run.
     synced_execution = remote.sync(execution, sync_nodes=True)
     node_keys = synced_execution.node_executions.keys()
+
+    # node_executions will fetch all the underlying node executions recursively.
+    # To fetch output of a specific node execution:
+    node_execution_output = synced_execution.node_executions["n1"].outputs["model_file"]
 
 """

--- a/cookbook/remote_access/inspecting_executions.py
+++ b/cookbook/remote_access/inspecting_executions.py
@@ -2,11 +2,11 @@
 Inspecting Workflow and Task Executions
 ---------------------------------------
 
-Using flyctl:
+Flytectl:
 =============
 
-Inspecting workflow and task executions are done in the same manner as below. For more details see the
-`flytectl API reference <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_get_execution.html>`__.
+Flytectl supports inspecting execution by retrieving its details. For a deeper dive, refer to the
+`API reference <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_get_execution.html>`__ guide.
 
 Monitor the execution by providing the execution id from create command which can be task or workflow execution. ::
 
@@ -25,11 +25,13 @@ To see the results of the execution you can inspect the node closure outputUri i
     "outputUri": "s3://my-s3-bucket/metadata/propeller/flytesnacks-development-<execid>/n0/data/0/outputs.pb"
 
 
-Using flytekit (python):
+FlyteRemote:
 ========================
-More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
+
+With FlyteRemote, you can fetch the inputs and outputs of execution and inspect them.
 
 .. code-block:: python
+
     from flytekit.remote import FlyteRemote
 
     # FlyteRemote object is the main entrypoint to API
@@ -48,10 +50,8 @@ More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/
     input_keys = execution.inputs.keys()
     output_keys = execution.outputs.keys()
 
-    # Fetching a specific output, say, a model file:
-    model_file = execution.outputs["model_file"]
-    with open(model_file) as f:
-        # use mode
-        ...
+    # You can use FlyteRemote.sync() to to sync the entity object's state with the remote state during the execution run
+    synced_execution = remote.sync(execution, sync_nodes=True)
+    node_keys = synced_execution.node_executions.keys()
 
 """

--- a/cookbook/remote_access/remote_launchplan.py
+++ b/cookbook/remote_access/remote_launchplan.py
@@ -2,8 +2,8 @@
 Running a Launchplan
 --------------------
 
-Flytectl:
-=============
+Flytectl
+========
 
 This is multi-steps process where we create an execution spec file, update the spec file and then create the execution.
 More details can be found `here <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_create_execution.html>`__.
@@ -28,10 +28,10 @@ More details can be found `here <https://docs.flyte.org/projects/flytectl/en/sta
 
     flytectl get execution -p flytesnacks -d development <execid>
 
-FlyteRemote:
-========================
+FlyteRemote
+===========
 
-More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
+A launch plan can be launched via FlyteRemote programmatically.
 
 .. code-block:: python
 
@@ -46,17 +46,14 @@ More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/
         default_domain="development",
     )
 
-    # Fetch workflow
-    flyte_workflow = remote.fetch_workflow(
-        name="workflows.statistics_flow", version="v1", project="flytesnacks", domain="development"
+    # Fetch launch plan
+    flyte_lp = remote.fetch_launch_plan(
+        name="workflows.example.wf", version="v1", project="flytesnacks", domain="development"
     )
-
-    # Get or create attached launchplan
-    flyte_launch_plan = LaunchPlan.get_or_create(name="workflows.statistics_plan", workflow=flyte_workflow)
 
     # Execute
     execution = remote.execute(
-        flyte_launch_plan, inputs={"mean": 1}, execution_name="my_execution", wait=True
+        flyte_launch_plan, inputs={"mean": 1}, execution_name="lp_execution", wait=True
     )
 
 """

--- a/cookbook/remote_access/remote_launchplan.py
+++ b/cookbook/remote_access/remote_launchplan.py
@@ -2,7 +2,7 @@
 Running a Launchplan
 --------------------
 
-Using flyctl:
+Flytectl:
 =============
 
 This is multi-steps process where we create an execution spec file, update the spec file and then create the execution.
@@ -28,11 +28,13 @@ More details can be found `here <https://docs.flyte.org/projects/flytectl/en/sta
 
     flytectl get execution -p flytesnacks -d development <execid>
 
-Using flytekit (python):
+FlyteRemote:
 ========================
+
 More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
 
 .. code-block:: python
+
     from flytekit.remote import FlyteRemote
     from flytekit.configuration import Config
     from flytekit import LaunchPlan
@@ -46,23 +48,15 @@ More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/
 
     # Fetch workflow
     flyte_workflow = remote.fetch_workflow(
-        name="my_workflow", version="v1", project="flytesnacks", domain="development"
+        name="workflows.statistics_flow", version="v1", project="flytesnacks", domain="development"
     )
 
     # Get or create attached launchplan
-    launch_plan = LaunchPlan.get_or_create(name="my_launch_plan", workflow=flyte_workflow)
+    flyte_launch_plan = LaunchPlan.get_or_create(name="workflows.statistics_plan", workflow=flyte_workflow)
 
-    # You can register launch plans
-    flyte_launch_plan = remote.register_launch_plan(entity=launch_plan, version="v1")
-
-    # Execute launch plan
+    # Execute
     execution = remote.execute(
-        flyte_launch_plan, inputs={...}, execution_name="my_execution", wait=True
+        flyte_launch_plan, inputs={"mean": 1}, execution_name="my_execution", wait=True
     )
-
-    # Inspecting execution
-    # The 'inputs' and 'outputs' correspond to the top-level execution or the workflow itself.
-    input_keys = execution.inputs.keys()
-    output_keys = execution.outputs.keys()
 
 """

--- a/cookbook/remote_access/remote_launchplan.py
+++ b/cookbook/remote_access/remote_launchplan.py
@@ -2,6 +2,9 @@
 Running a Launchplan
 --------------------
 
+Using flyctl:
+=============
+
 This is multi-steps process where we create an execution spec file, update the spec file and then create the execution.
 More details can be found `here <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_create_execution.html>`__.
 
@@ -24,5 +27,42 @@ More details can be found `here <https://docs.flyte.org/projects/flytectl/en/sta
 **Monitor the execution by providing the execution id from create command** ::
 
     flytectl get execution -p flytesnacks -d development <execid>
+
+Using flytekit (python):
+========================
+More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
+
+.. code-block:: python
+    from flytekit.remote import FlyteRemote
+    from flytekit.configuration import Config
+    from flytekit import LaunchPlan
+
+    # FlyteRemote object is the main entrypoint to API
+    remote = FlyteRemote(
+        config=Config.for_endpoint(endpoint="flyte.example.net"),
+        default_project="flytesnacks",
+        default_domain="development",
+    )
+
+    # Fetch workflow
+    flyte_workflow = remote.fetch_workflow(
+        name="my_workflow", version="v1", project="flytesnacks", domain="development"
+    )
+
+    # Get or create attached launchplan
+    launch_plan = LaunchPlan.get_or_create(name="my_launch_plan", workflow=flyte_workflow)
+
+    # You can register launch plans
+    flyte_launch_plan = remote.register_launch_plan(entity=launch_plan, version="v1")
+
+    # Execute launch plan
+    execution = remote.execute(
+        flyte_launch_plan, inputs={...}, execution_name="my_execution", wait=True
+    )
+
+    # Inspecting execution
+    # The 'inputs' and 'outputs' correspond to the top-level execution or the workflow itself.
+    input_keys = execution.inputs.keys()
+    output_keys = execution.outputs.keys()
 
 """

--- a/cookbook/remote_access/remote_task.py
+++ b/cookbook/remote_access/remote_task.py
@@ -2,32 +2,32 @@
 Running a Task
 --------------------
 
-Using flyctl:
+Flytectl:
 =============
 
-This is multi-steps process as well where we create an execution spec file, update the spec file and then create the execution.
-More details can be found `here <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_create_execution.html>`__
+This is a multi-step process where we create an execution spec file, update the spec file, and then create the execution.
+More details can be found in the `Flytectl API reference <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_create_execution.html>`__.
 
 **Generate execution spec file** ::
 
-    flytectl get tasks -d development -p flytectldemo core.advanced.merge_sort.merge  --latest --execFile exec_spec.yaml
+    flytectl get tasks -d development -p flytectldemo workflows.descriptive_statistics  --latest --execFile exec_spec.yaml
 
 **Update the input spec file for arguments to the workflow** ::
 
             iamRoleARN: 'arn:aws:iam::12345678:role/defaultrole'
             inputs:
-              sorted_list1:
+              mean:
+              - 1
+              - 2
+              - 3
+              other_input:
               - 2
               - 4
               - 6
-              sorted_list2:
-              - 1
-              - 3
-              - 5
             kubeServiceAcct: ""
             targetDomain: ""
             targetProject: ""
-            task: core.advanced.merge_sort.merge
+            task: workflows.descriptive_statistics
             version: "v1"
 
 **Create execution using the exec spec file** ::
@@ -40,11 +40,13 @@ More details can be found `here <https://docs.flyte.org/projects/flytectl/en/sta
     flytectl get execution -p flytesnacks -d development <execid>
 
 
-Using flytekit (python):
+FlyteRemote:
 ========================
-More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
+
+A task can be launched via FlyteRemote programmatically.
 
 .. code-block:: python
+
     from flytekit.remote import FlyteRemote
     from flytekit.configuration import Config, SerializationSettings
 
@@ -56,25 +58,17 @@ More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/
     )
 
     # Get Task
-    task_1 = remote.fetch_task(name="core.basic.hello_world.say_hello", version="v1")
+    flyte_task = remote.fetch_task(name="workflows.descriptive_statistics", version="v1")
 
-    # Tasks, workflows, and launch plans can be registered using FlyteRemote.
-    flyte_entity = ...
     flyte_task = remote.register_task(
-        entity=flyte_entity,
+        entity=flyte_task,
         serialization_settings=SerializationSettings(image_config=None),
         version="v1",
     )
-    flyte_workflow = remote.register_workflow(
-        entity=flyte_entity,
-        serialization_settings=SerializationSettings(image_config=None),
-        version="v1",
-    )
-    flyte_launch_plan = remote.register_launch_plan(entity=flyte_entity, version="v1")
 
     # Run Task
     execution = remote.execute(
-        task_1, inputs={...}, execution_name="my_execution", wait=True
+         flyte_task, inputs={"mean": 1}, execution_name="task_execution", wait=True
     )
 
     # Inspecting execution

--- a/cookbook/remote_access/remote_task.py
+++ b/cookbook/remote_access/remote_task.py
@@ -2,6 +2,9 @@
 Running a Task
 --------------------
 
+Using flyctl:
+=============
+
 This is multi-steps process as well where we create an execution spec file, update the spec file and then create the execution.
 More details can be found `here <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_create_execution.html>`__
 
@@ -35,5 +38,48 @@ More details can be found `here <https://docs.flyte.org/projects/flytectl/en/sta
 **Monitor the execution by providing the execution id from create command** ::
 
     flytectl get execution -p flytesnacks -d development <execid>
+
+
+Using flytekit (python):
+========================
+More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
+
+.. code-block:: python
+    from flytekit.remote import FlyteRemote
+    from flytekit.configuration import Config, SerializationSettings
+
+    # FlyteRemote object is the main entrypoint to API
+    remote = FlyteRemote(
+        config=Config.for_endpoint(endpoint="flyte.example.net"),
+        default_project="flytesnacks",
+        default_domain="development",
+    )
+
+    # Get Task
+    task_1 = remote.fetch_task(name="core.basic.hello_world.say_hello", version="v1")
+
+    # Tasks, workflows, and launch plans can be registered using FlyteRemote.
+    flyte_entity = ...
+    flyte_task = remote.register_task(
+        entity=flyte_entity,
+        serialization_settings=SerializationSettings(image_config=None),
+        version="v1",
+    )
+    flyte_workflow = remote.register_workflow(
+        entity=flyte_entity,
+        serialization_settings=SerializationSettings(image_config=None),
+        version="v1",
+    )
+    flyte_launch_plan = remote.register_launch_plan(entity=flyte_entity, version="v1")
+
+    # Run Task
+    execution = remote.execute(
+        task_1, inputs={...}, execution_name="my_execution", wait=True
+    )
+
+    # Inspecting execution
+    # The 'inputs' and 'outputs' correspond to the top-level execution or the workflow itself.
+    input_keys = execution.inputs.keys()
+    output_keys = execution.outputs.keys()
 
 """

--- a/cookbook/remote_access/remote_task.py
+++ b/cookbook/remote_access/remote_task.py
@@ -2,32 +2,27 @@
 Running a Task
 --------------------
 
-Flytectl:
-=============
+Flytectl
+========
 
 This is a multi-step process where we create an execution spec file, update the spec file, and then create the execution.
 More details can be found in the `Flytectl API reference <https://docs.flyte.org/projects/flytectl/en/stable/gen/flytectl_create_execution.html>`__.
 
 **Generate execution spec file** ::
 
-    flytectl get tasks -d development -p flytectldemo workflows.descriptive_statistics  --latest --execFile exec_spec.yaml
+    flytectl get tasks -d development -p flytesnacks workflows.example.generate_normal_df  --latest --execFile exec_spec.yaml
 
 **Update the input spec file for arguments to the workflow** ::
 
             iamRoleARN: 'arn:aws:iam::12345678:role/defaultrole'
             inputs:
-              mean:
-              - 1
-              - 2
-              - 3
-              other_input:
-              - 2
-              - 4
-              - 6
+              n: 200
+              mean: 0.0
+              sigma: 1.0
             kubeServiceAcct: ""
             targetDomain: ""
             targetProject: ""
-            task: workflows.descriptive_statistics
+            task: workflows.example.generate_normal_df
             version: "v1"
 
 **Create execution using the exec spec file** ::
@@ -40,8 +35,8 @@ More details can be found in the `Flytectl API reference <https://docs.flyte.org
     flytectl get execution -p flytesnacks -d development <execid>
 
 
-FlyteRemote:
-========================
+FlyteRemote
+===========
 
 A task can be launched via FlyteRemote programmatically.
 
@@ -58,21 +53,21 @@ A task can be launched via FlyteRemote programmatically.
     )
 
     # Get Task
-    flyte_task = remote.fetch_task(name="workflows.descriptive_statistics", version="v1")
+    flyte_task = remote.fetch_task(name="workflows.example.generate_normal_df", version="v1")
 
     flyte_task = remote.register_task(
         entity=flyte_task,
         serialization_settings=SerializationSettings(image_config=None),
-        version="v1",
+        version="v2",
     )
 
     # Run Task
     execution = remote.execute(
-         flyte_task, inputs={"mean": 1}, execution_name="task_execution", wait=True
+         flyte_task, inputs={"n": 200, "mean": 0.0, "sigma": 1.0}, execution_name="task_execution", wait=True
     )
 
     # Inspecting execution
-    # The 'inputs' and 'outputs' correspond to the top-level execution or the workflow itself.
+    # The 'inputs' and 'outputs' correspond to the task execution.
     input_keys = execution.inputs.keys()
     output_keys = execution.outputs.keys()
 

--- a/cookbook/remote_access/remote_workflow.py
+++ b/cookbook/remote_access/remote_workflow.py
@@ -14,10 +14,10 @@ A ``default launchplan`` has the same name as the workflow and all argument defa
 One difference between running a task and a workflow via launchplans is that launchplans cannot be associated with a
 task. This is to avoid triggers and scheduling.
 
-FlyteRemote:
-========================
+FlyteRemote
+===========
 
-Workflows and launchplans can be run through FlyteRemote programmatically.
+Workflows can be executed with FlyteRemote because under the hood it fetches and triggers a default launch plan.
 
 .. code-block:: python
 
@@ -32,11 +32,11 @@ Workflows and launchplans can be run through FlyteRemote programmatically.
     )
 
     # Fetch workflow
-    flyte_workflow = remote.fetch_workflow(name="workflows.statistics_flow", version="v1")
+    flyte_workflow = remote.fetch_workflow(name="workflows.example.wf", version="v1")
 
     # Execute
     execution = remote.execute(
-        flyte_workflow, inputs={"mean": 1}, execution_name="my_execution", wait=True
+        flyte_workflow, inputs={"mean": 1}, execution_name="workflow_execution", wait=True
     )
 
 """

--- a/cookbook/remote_access/remote_workflow.py
+++ b/cookbook/remote_access/remote_workflow.py
@@ -14,4 +14,29 @@ A ``default launchplan`` has the same name as the workflow and all argument defa
 One difference between running a task and a workflow via launchplans is that launchplans cannot be associated with a
 task. This is to avoid triggers and scheduling.
 
+Using flytekit (python):
+========================
+More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
+
+.. code-block:: python
+    from flytekit.remote import FlyteRemote
+    from flytekit.configuration import Config
+
+    # FlyteRemote object is the main entrypoint to API
+    remote = FlyteRemote(
+        config=Config.for_endpoint(endpoint="flyte.example.net"),
+        default_project="flytesnacks",
+        default_domain="development",
+    )
+
+    # Fetch workflow or launch_plan
+    flyte_workflow = remote.fetch_workflow(name="my_workflow", version="v1")
+    flyte_launch_plan = remote.fetch_launch_plan(name="my_launch_plan", version="v1")
+
+    # Execute the flyte_entity
+    # flyte_entity being either 'flyte_workflow' or 'flyte_launch_plan'
+    execution = remote.execute(
+        flyte_entity, inputs={...}, execution_name="my_execution", wait=True
+    )
+
 """

--- a/cookbook/remote_access/remote_workflow.py
+++ b/cookbook/remote_access/remote_workflow.py
@@ -14,11 +14,13 @@ A ``default launchplan`` has the same name as the workflow and all argument defa
 One difference between running a task and a workflow via launchplans is that launchplans cannot be associated with a
 task. This is to avoid triggers and scheduling.
 
-Using flytekit (python):
+FlyteRemote:
 ========================
-More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/projects/flytekit/en/latest/remote.html>`__
+
+Workflows and launchplans can be run through FlyteRemote programmatically.
 
 .. code-block:: python
+
     from flytekit.remote import FlyteRemote
     from flytekit.configuration import Config
 
@@ -29,14 +31,12 @@ More details can be found in the docs for  `FlyteRemote <https://docs.flyte.org/
         default_domain="development",
     )
 
-    # Fetch workflow or launch_plan
-    flyte_workflow = remote.fetch_workflow(name="my_workflow", version="v1")
-    flyte_launch_plan = remote.fetch_launch_plan(name="my_launch_plan", version="v1")
+    # Fetch workflow
+    flyte_workflow = remote.fetch_workflow(name="workflows.statistics_flow", version="v1")
 
-    # Execute the flyte_entity
-    # flyte_entity being either 'flyte_workflow' or 'flyte_launch_plan'
+    # Execute
     execution = remote.execute(
-        flyte_entity, inputs={...}, execution_name="my_execution", wait=True
+        flyte_workflow, inputs={"mean": 1}, execution_name="my_execution", wait=True
     )
 
 """


### PR DESCRIPTION
The request: 
The "Remote Access" [section](https://docs.flyte.org/projects/cookbook/en/latest/auto/remote_access/remote_workflow.html) currently has flytectl commands to register and run flyte entities. FlyteRemote examples need to be appended to each of the doc pages to showcase accessing the backend programmatically through an API.

What was done:

The remote access docs in the user guide were edited to include examples of using the python sdk flytekit.

closes [2769](https://github.com/flyteorg/flyte/issues/2769)