### PR TITLE
Use inputs in raw containers example

### DIFF
--- a/cookbook/core/containerization/raw-containers-supporting-files/per-language/haskell/calculate-ellipse-area.hs
+++ b/cookbook/core/containerization/raw-containers-supporting-files/per-language/haskell/calculate-ellipse-area.hs
@@ -8,14 +8,12 @@ calculateEllipseArea a b = pi * a * b
 
 main = do
   args <- getArgs
-  let input_a = args!!0 ++ "/a"
-      input_b = args!!0 ++ "/b"
-  a <- readFile input_a
-  b <- readFile input_b
+  let a = args!!0
+      b = args!!1
 
   let area = calculateEllipseArea (read a::Float) (read b::Float)
 
-  let output_area = args!!1 ++ "/area"
-      output_metadata = args!!1 ++ "/metadata"
+  let output_area = args!!2 ++ "/area"
+      output_metadata = args!!2 ++ "/metadata"
   writeFile output_area (show area)
   writeFile output_metadata "[from haskell rawcontainer]"

--- a/cookbook/core/containerization/raw-containers-supporting-files/per-language/julia/calculate-ellipse-area.jl
+++ b/cookbook/core/containerization/raw-containers-supporting-files/per-language/julia/calculate-ellipse-area.jl
@@ -5,12 +5,6 @@ function calculate_area(a, b)
     π * a * b
 end
 
-function read_input(input_dir, v)
-    open(@sprintf "%s/%s" input_dir v) do file
-        parse.(Float64, read(file, String))
-    end
-end
-
 function write_output(output_dir, output_file, v)
     output_path = @sprintf "%s/%s" output_dir output_file
     open(output_path, "w") do file
@@ -18,9 +12,9 @@ function write_output(output_dir, output_file, v)
     end
 end
 
-function main(input_dir, output_dir)
-    a = read_input(input_dir, 'a')
-    b = read_input(input_dir, 'b')
+function main(a, b, output_dir)
+    a = parse.(Float64, a)
+    b = parse.(Float64, b)
 
     area = calculate_area(a, b)
 
@@ -30,7 +24,8 @@ end
 
 # the keyword ARGS is a special value that contains the command-line arguments
 # julia arrays are 1-indexed
-input_dir = ARGS[1]
-output_dir = ARGS[2]
+a = ARGS[1]
+b = ARGS[2]
+output_dir = ARGS[3]
 
-main(input_dir, output_dir)
+main(a, b, output_dir)

--- a/cookbook/core/containerization/raw-containers-supporting-files/per-language/python/calculate-ellipse-area.py
+++ b/cookbook/core/containerization/raw-containers-supporting-files/per-language/python/calculate-ellipse-area.py
@@ -2,11 +2,6 @@ import math
 import sys
 
 
-def read_input(input_dir, v):
-    with open(f"{input_dir}/{v}", "r") as f:
-        return float(f.read())
-
-
 def write_output(output_dir, output_file, v):
     with open(f"{output_dir}/{output_file}", "w") as f:
         f.write(str(v))
@@ -16,9 +11,9 @@ def calculate_area(a, b):
     return math.pi * a * b
 
 
-def main(input_dir, output_dir):
-    a = read_input(input_dir, "a")
-    b = read_input(input_dir, "b")
+def main(a, b, output_dir):
+    a = float(a)
+    b = float(b)
 
     area = calculate_area(a, b)
 
@@ -27,7 +22,8 @@ def main(input_dir, output_dir):
 
 
 if __name__ == "__main__":
-    input_dir = sys.argv[1]
-    output_dir = sys.argv[2]
+    a = sys.argv[1]
+    b = sys.argv[2]
+    output_dir = sys.argv[3]
 
-    main(input_dir, output_dir)
+    main(a, b, output_dir)

--- a/cookbook/core/containerization/raw-containers-supporting-files/per-language/r/Dockerfile
+++ b/cookbook/core/containerization/raw-containers-supporting-files/per-language/r/Dockerfile
@@ -3,8 +3,3 @@ FROM r-base
 WORKDIR /root
 
 COPY *.R /root/
-
-# Not sure whether this a horrible hack. I couldn't
-# find a better way to install a package via command
-# line
-RUN Rscript --save install-readr.R

--- a/cookbook/core/containerization/raw-containers-supporting-files/per-language/r/calculate-ellipse-area.R
+++ b/cookbook/core/containerization/raw-containers-supporting-files/per-language/r/calculate-ellipse-area.R
@@ -1,12 +1,10 @@
-library(readr)
+#!/usr/bin/env Rscript
 
 args = commandArgs(trailingOnly=TRUE)
 
-input_dir = args[1]
-output_dir = args[2]
-
-a = read_lines(sprintf("%s/%s", input_dir, 'a'))
-b = read_lines(sprintf("%s/%s", input_dir, 'b'))
+a = args[1]
+b = args[2]
+output_dir = args[3]
 
 area <- pi * as.double(a) * as.double(b)
 print(area)

--- a/cookbook/core/containerization/raw-containers-supporting-files/per-language/shell/calculate-ellipse-area.sh
+++ b/cookbook/core/containerization/raw-containers-supporting-files/per-language/shell/calculate-ellipse-area.sh
@@ -1,8 +1,5 @@
 #! /usr/bin/env sh
 
-a=$(cat $1/a)
-b=$(cat $1/b)
+echo "4*a(1) * $1 * $2" | bc -l | tee $3/area
 
-echo "4*a(1) * $a * $b" | bc -l | tee $2/area
-
-echo "[from shell rawcontainer]" | tee $2/metadata
+echo "[from shell rawcontainer]" | tee $3/metadata

--- a/cookbook/core/containerization/raw_container.py
+++ b/cookbook/core/containerization/raw_container.py
@@ -35,10 +35,11 @@ calculate_ellipse_area_shell = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteorg/rawcontainers-shell:v1",
+    image="ghcr.io/flyteorg/rawcontainers-shell:v2",
     command=[
         "./calculate-ellipse-area.sh",
-        "/var/inputs",
+        "{{.inputs.a}}",
+        "{{.inputs.b}}",
         "/var/outputs",
     ],
 )
@@ -49,11 +50,12 @@ calculate_ellipse_area_python = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteorg/rawcontainers-python:v1",
+    image="ghcr.io/flyteorg/rawcontainers-python:v2",
     command=[
         "python",
         "calculate-ellipse-area.py",
-        "/var/inputs",
+        "{{.inputs.a}}",
+        "{{.inputs.b}}",
         "/var/outputs",
     ],
 )
@@ -64,12 +66,13 @@ calculate_ellipse_area_r = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteorg/rawcontainers-r:v1",
+    image="ghcr.io/flyteorg/rawcontainers-r:v2",
     command=[
         "Rscript",
         "--vanilla",
         "calculate-ellipse-area.R",
-        "/var/inputs",
+        "{{.inputs.a}}",
+        "{{.inputs.b}}",
         "/var/outputs",
     ],
 )
@@ -80,10 +83,11 @@ calculate_ellipse_area_haskell = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteorg/rawcontainers-haskell:v1",
+    image="ghcr.io/flyteorg/rawcontainers-haskell:v2",
     command=[
         "./calculate-ellipse-area",
-        "/var/inputs",
+        "{{.inputs.a}}",
+        "{{.inputs.b}}",
         "/var/outputs",
     ],
 )
@@ -94,11 +98,12 @@ calculate_ellipse_area_julia = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteorg/rawcontainers-julia:v1",
+    image="ghcr.io/flyteorg/rawcontainers-julia:v2",
     command=[
         "julia",
         "calculate-ellipse-area.jl",
-        "/var/inputs",
+        "{{.inputs.a}}",
+        "{{.inputs.b}}",
         "/var/outputs",
     ],
 )


### PR DESCRIPTION
This PR changes the raw containers example to showcase how to pass inputs in the invocation of the task (as opposed to reading it from the mounted files directly).

Tested it in a sandbox.

[Original slack thread](https://flyte-org.slack.com/archives/CP2HDHKE1/p1667486246961349).

Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>