### PR TITLE
Document IgnoreOutputs exception

### DIFF
--- a/cookbook/integrations/kubernetes/kfmpi/mpi_mnist.py
+++ b/cookbook/integrations/kubernetes/kfmpi/mpi_mnist.py
@@ -163,3 +163,9 @@ def horovod_training_wf(
 if __name__ == "__main__":
     model, plot, logs = horovod_training_wf()
     print(f"Model: {model}, plot PNG: {plot}, Tensorboard Log Dir: {logs}")
+
+# %%
+# Control which rank returns its value
+# ====================================
+# In distributed training, the return values from different workers might differ.
+# If you want to control which of the workers returns its return value to subsequent tasks in the workflow, you can raise a `IgnoreOutputs <https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.core.base_task.IgnoreOutputs.html>`_ exception for all other ranks.

--- a/cookbook/integrations/kubernetes/kfpytorch/pytorch_mnist.py
+++ b/cookbook/integrations/kubernetes/kfpytorch/pytorch_mnist.py
@@ -340,7 +340,7 @@ if __name__ == "__main__":
 # Refer to .. TODO.
 # You can retrieve the outputs - which will be a path to a blob store like S3, GCS, minio, etc. Tensorboad can be
 # pointed to on your local laptop to visualize the results.
-
+#
 # Control which rank returns its value
 # ====================================
 # In distributed training, the return values from different workers might differ.

--- a/cookbook/integrations/kubernetes/kfpytorch/pytorch_mnist.py
+++ b/cookbook/integrations/kubernetes/kfpytorch/pytorch_mnist.py
@@ -340,3 +340,8 @@ if __name__ == "__main__":
 # Refer to .. TODO.
 # You can retrieve the outputs - which will be a path to a blob store like S3, GCS, minio, etc. Tensorboad can be
 # pointed to on your local laptop to visualize the results.
+
+# Control which rank returns its value
+# ====================================
+# In distributed training, the return values from different workers might differ.
+# If you want to control which of the workers returns its return value to subsequent tasks in the workflow, you can raise a `IgnoreOutputs <https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.core.base_task.IgnoreOutputs.html>`_ exception for all other ranks.

--- a/cookbook/integrations/kubernetes/kftensorflow/tf_mnist.py
+++ b/cookbook/integrations/kubernetes/kftensorflow/tf_mnist.py
@@ -242,3 +242,9 @@ def mnist_tensorflow_workflow(
 # We can also run the code locally.
 if __name__ == "__main__":
     print(mnist_tensorflow_workflow())
+
+# %%
+# Control which rank returns its value
+# ====================================
+# In distributed training, the return values from different workers might differ.
+# If you want to control which of the workers returns its return value to subsequent tasks in the workflow, you can raise a `IgnoreOutputs <https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.core.base_task.IgnoreOutputs.html>`_ exception for all other ranks.


### PR DESCRIPTION
When trying to control which of the distributed workers of a PyTorch task returns its values to the subsequent tasks in the workflow (in the case that they are not the same), I couldn't find the information in the documentation and asked on Slack.

In this PR I document the solution I was guided to on Slack in the mnist examples of distributed pytorch, tf, and mpi as this is where I first looked for an answer.
It gives me a bit of sadness to propose to reproduce the same sentence three times, however, I cannot find one overarching documentation page for distributed training and as a user of the respective frameworks, this is where I would first look.
Do you have a better proposition for where to document this?