### PR TITLE
Fix walkthrough command for pima diabetes classification example

### DIFF
--- a/cookbook/case_studies/ml_training/pima_diabetes/README.rst
+++ b/cookbook/case_studies/ml_training/pima_diabetes/README.rst
@@ -48,4 +48,4 @@ Run workflows in this directory with the custom-built base image:
 
 .. prompt:: bash $
 
-     pyflyte run --remote diabetes.py:diabetes_xgboost_model --image ghcr.io/flyteorg/flytecookbook:pima_diabetes-latest
+     pyflyte run --remote --image ghcr.io/flyteorg/flytecookbook:pima_diabetes-latest diabetes.py diabetes_xgboost_model


### PR DESCRIPTION
The current "Walkthrough" command for the [Diabetes Classification example](https://docs.flyte.org/projects/cookbook/en/latest/auto/case_studies/ml_training/pima_diabetes/index.html#walkthrough) has its arguments in an incorrect order, which causes the command to fail with error `Error: No such option: --image`. This PR puts the arguments in the correct order.

Signed-off-by: Kanyes Thaker <kanyes.thaker@gmail.com>