### PR TITLE
Minor typo in Golang

### DIFF
--- a/cookbook/core/extend_flyte/README.rst
+++ b/cookbook/core/extend_flyte/README.rst
@@ -149,8 +149,8 @@ of the plugin.
    * - Pros
      - Cons
    * - Service oriented way of deploying new plugins - strong contracts. Maintainers can deploy new versions of the backend plugin, fix bugs, without needing the users to upgrade libraries, etc.
-     - Need to be implemented in GOlang.
-   * - Drastically cheaper and more efficient to execute. FlytePropeller is written in GOlang and uses an event loop model. Each process of FlytePropeller can execute thousands of tasks concurrently.
+     - Need to be implemented in Golang.
+   * - Drastically cheaper and more efficient to execute. FlytePropeller is written in Golang and uses an event loop model. Each process of FlytePropeller can execute thousands of tasks concurrently.
      - Needs a FlytePropeller build (*currently*).
    * - Flyte guarantees resource cleanup.
      - Need to implement contract in a spec language like protobuf, OpenAPI, etc.


### PR DESCRIPTION
Go language is uniformly stylized as "Golang" not "GOlang

Signed-off-by: David Q Mertz <mertz@gnosis.cx>