### PR TITLE
fix file name to enable appearance in left nav

### DIFF
--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -119,8 +119,8 @@ class CustomSorter(FileNameSortKey):
         "sql_alchemy.py",
         "whylogs_example.py",
         ## Kubernetes
-        "dask.py",
         "pod.py",
+        "dask_example.py",
         "pyspark_pi.py",
         "dataframe_passing.py",
         "pytorch_mnist.py",

--- a/cookbook/docs/index.rst
+++ b/cookbook/docs/index.rst
@@ -184,6 +184,7 @@ Table of Contents
    auto/integrations/flytekit_plugins/whylogs_examples/index
    auto/integrations/flytekit_plugins/onnx_examples/index
    auto/integrations/kubernetes/pod/index
+   auto/integrations/kubernetes/k8s_dask/index
    auto/integrations/kubernetes/k8s_spark/index
    auto/integrations/kubernetes/kfpytorch/index
    auto/integrations/kubernetes/kftensorflow/index


### PR DESCRIPTION
Signed-off-by: Peeter Piegaze <peeter@union.ai>

Fixed the name listed in `conf.py` (`dask.py`) so that it matches the actual name of the file (`dask_example.py`) in `integrations/kubernetes/k8s_dask/` enabling the page to appear in the left nav.

