### PR TITLE
scikit learn dependency

### DIFF
--- a/cookbook/docs/index.md
+++ b/cookbook/docs/index.md
@@ -69,6 +69,12 @@ First install [flytekit](https://pypi.org/project/flytekit/), Flyte's Python SDK
 pip install flytekit
 ```
 
+Make sure you have the [sklearn](https://scikit-learn.org/stable) package installed as well.
+
+```{prompt} bash $
+pip install scikit-learn
+```
+
 Then install [flytectl](https://docs.flyte.org/projects/flytectl/en/latest/),
 which the command-line interface for interacting with a Flyte backend.
 

--- a/cookbook/docs/index.md
+++ b/cookbook/docs/index.md
@@ -69,7 +69,7 @@ First install [flytekit](https://pypi.org/project/flytekit/), Flyte's Python SDK
 pip install flytekit
 ```
 
-Make sure you have the [sklearn](https://scikit-learn.org/stable) package installed as well.
+The [sklearn](https://scikit-learn.org/stable) package is a secondary dependency for this demo.
 
 ```{prompt} bash $
 pip install scikit-learn


### PR DESCRIPTION
**Motivation**

The onboarding Flyte document almost entirely provides all of the requirements needed to run the quickstart; however the `scikit-learn` dependency (with a package named sklearn) is not explicitly called out as a requirement.

**Fix**
Added a small callout below the flytekit pip package that specifies `scikit-learn` as a clear dependency for the quick start demo.