### PR TITLE
added scikit-learn dependency callout

### DIFF
--- a/cookbook/docs/index.md
+++ b/cookbook/docs/index.md
@@ -69,6 +69,12 @@ First install [flytekit](https://pypi.org/project/flytekit/), Flyte's Python SDK
 pip install flytekit
 ```
 
+The [sklearn](https://scikit-learn.org/stable) package is a secondary dependency for this demo.
+
+```{prompt} bash $
+pip install scikit-learn
+```
+
 Then install [flytectl](https://docs.flyte.org/projects/flytectl/en/latest/),
 which the command-line interface for interacting with a Flyte backend.
 

--- a/cookbook/docs/index.md
+++ b/cookbook/docs/index.md
@@ -63,16 +63,10 @@ and [Containerd](https://containerd.io/)), and ensure that the associated client
 daemon is running (e.g. the Docker daemon).
 ```
 
-First install [flytekit](https://pypi.org/project/flytekit/), Flyte's Python SDK.
+First install [flytekit](https://pypi.org/project/flytekit/), Flyte's Python SDK and [Scikit-learn](https://scikit-learn.org/stable).
 
 ```{prompt} bash $
-pip install flytekit
-```
-
-The [sklearn](https://scikit-learn.org/stable) package is a secondary dependency for this demo.
-
-```{prompt} bash $
-pip install scikit-learn
+pip install flytekit scikit-learn
 ```
 
 Then install [flytectl](https://docs.flyte.org/projects/flytectl/en/latest/),


### PR DESCRIPTION
**Motivation**

The onboarding Flyte document almost entirely provides all of the requirements needed to run the quickstart; however the `scikit-learn` dependency (with a package named sklearn) is not explicitly called out as a requirement.

**Fix**
Added a small callout below the flytekit pip package that specifies `scikit-learn` as a clear dependency for the quick start demo.