### PR TITLE
Add retry to interruptible docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   hooks:
     - id: black
 - repo: https://github.com/PyCQA/isort
-  rev:  5.9.3
+  rev:  5.12.0
   hooks:
     - id: isort
       args: ["--profile", "black"]

--- a/cookbook/core/containerization/spot_instances.py
+++ b/cookbook/core/containerization/spot_instances.py
@@ -40,11 +40,11 @@ Using Spot/Preemptible Instances
 #
 # Setting Interruptible
 # ^^^^^^^^^^^^^^^^^^^^^
-# To run your workload on a spot/preemptible instance, you can set interruptible to ``True``. For example:
+# To run your workload on a spot/preemptible instance, you can set interruptible to ``True``. In case you would like to automatically retry in case the node gets preemted, please also make sure to set at least one retry. For example:
 #
 # .. code-block:: python
 #
-#    @task(cache_version='1', interruptible=True)
+#    @task(cache_version='1', interruptible=True, retries=1)
 #    def add_one_and_print(value_to_print: int) -> int:
 #        return value_to_print + 1
 
@@ -52,7 +52,7 @@ Using Spot/Preemptible Instances
 # By setting this value, Flyte will schedule your task on an auto-scaling group (ASG) with only spot instances.
 #
 # .. note::
-#   If your task gets preempted, Flyte will retry your task on a non-spot (regular) instance. This retry will not count towards a retry that a user sets.
+#   If your task gets preempted, Flyte will retry your task on a non-spot (regular) instance. This retry will not count towards a retry that a user sets. Please note that tasks will only be retried if at least one retry is allowed using the `retries` parameter in the `task` decorator.
 #
 # Which Tasks Should Be Set To Interruptible?
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR adds a small note about requiring `retries` when using `interruptible` nodes. 

It also updates the `isort` pre-commit version from `5.9.3` to `5.12.0` to avoid the issue similar to https://github.com/PyCQA/isort/issues/2077