### PR TITLE
Upgrading aws sdk to use WebIdentityTokenCredentialsProvider

### DIFF
--- a/cookbook/integrations/kubernetes/k8s_spark/Dockerfile
+++ b/cookbook/integrations/kubernetes/k8s_spark/Dockerfile
@@ -34,7 +34,7 @@ COPY k8s_spark/requirements.txt /root
 RUN pip install -r /root/requirements.txt
 
 RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.2/hadoop-aws-3.2.2.jar -P /opt/spark/jars && \
-    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.563/aws-java-sdk-bundle-1.11.563.jar -P /opt/spark/jars
+    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P /opt/spark/jars
 
 # Copy the makefile targets to expose on the container. This makes it easier to register.
 # Delete this after we update CI


### PR DESCRIPTION
Encountered permission issue when running spark history server on one of the deployments

The issue being spark history server events requires to use WebIdentityTokenProvider to authenticate using the annotated role inorder to write events to the configured bucket


The first version where this idneitty provider came in  was in 1.11.603 which is higher than what we have in our dockerfile

 https://github.com/aws/aws-sdk-java/commits/master/aws-java-sdk-core/src/main/java/com/amazonaws/auth/WebIdentityTokenCredentialsProvider.java


Testing this on internal tenant and saw successful events writes in the configured history server bucket