### PR TITLE
Improve documentation consistency and remove @task

### DIFF
--- a/cookbook/core/flyte_basics/task_cache.py
+++ b/cookbook/core/flyte_basics/task_cache.py
@@ -135,8 +135,7 @@ def wf(a: int, b: str):
 # For example, in order to cache the result of calls to ``bar``, you can rewrite the code above like this:
 
 
-@task
-def hash_pandas_dataframe_function(df: pandas.DataFrame) -> str:
+def hash_pandas_dataframe(df: pandas.DataFrame) -> str:
     return str(pandas.util.hash_pandas_object(df))
 
 
@@ -144,7 +143,7 @@ def hash_pandas_dataframe_function(df: pandas.DataFrame) -> str:
 def foo_1(  # noqa: F811
     a: int, b: str  # noqa: F821
 ) -> Annotated[
-    pandas.DataFrame, HashMethod(hash_pandas_dataframe_function)  # noqa: F821
+    pandas.DataFrame, HashMethod(hash_pandas_dataframe)  # noqa: F821
 ]:  # noqa: F821
     df = pandas.DataFrame(...)  # noqa: F821
     ...


### PR DESCRIPTION
Different function names were being used for the hash function, so I fixed those. Further, the @task on the hash_pandas_dataframe_function would actually cause an error if it was added to the hash function. Beyond being generally incorrect behavior, it would cause an error due to the parameter being implicitly passed as a positional argument even though tasks only accept keyword arguments.