### PR TITLE
clean up warnings in getting started docs

### DIFF
--- a/cookbook/docs/conf.py
+++ b/cookbook/docs/conf.py
@@ -510,3 +510,6 @@ mermaid_init_js = "mermaid.initialize({startOnLoad:false});"
 
 # Disable warnings from flytekit
 os.environ["FLYTE_SDK_LOGGING_LEVEL_ROOT"] = "50"
+
+# Disable warnings from tensorflow
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = "3"

--- a/cookbook/docs/getting_started/visualizing_artifacts.md
+++ b/cookbook/docs/getting_started/visualizing_artifacts.md
@@ -217,6 +217,10 @@ Then we can use the `Annotated` type to override the default renderer of the
 `pandas.DataFrame` type:
 
 ```{code-cell} ipython
+---
+tags: [remove-output]
+---
+
 try:
     from typing import Annotated
 except ImportError:

--- a/cookbook/docs/getting_started/visualizing_artifacts.md
+++ b/cookbook/docs/getting_started/visualizing_artifacts.md
@@ -120,7 +120,7 @@ class DeckFilter(logging.Filter):
             task, filepath = matches.group(1), matches.group(2)
             self.logs.append(self.formatter.format(record))
             self.deck_files[task] = re.sub("^file://", "", filepath)
-        return True
+        return False
 
 def cp_deck(src):
     src = Path(src)

--- a/cookbook/docs/getting_started/visualizing_artifacts.md
+++ b/cookbook/docs/getting_started/visualizing_artifacts.md
@@ -138,6 +138,9 @@ logger.addFilter(deck_filter)
 ```
 
 ```{code-cell} ipython3
+---
+tags: [remove-output]
+---
 wf(sample_frac=1.0, random_state=42)
 ```
 


### PR DESCRIPTION
This PR cleans up unnecessary warnings that are printed out in the getting started docs.