### PR TITLE
Remove note about python versions from getting started

### DIFF
--- a/cookbook/docs/index.md
+++ b/cookbook/docs/index.md
@@ -69,10 +69,6 @@ Kubernetes cluster so that you can interact with it on your machine.
 
 First install [flytekit](https://pypi.org/project/flytekit/), Flyte's Python SDK and [Scikit-learn](https://scikit-learn.org/stable).
 
-```{note}
-`flytekit` currently requires Python version `>=3.7, <=3.10`.
-```
-
 ```{prompt} bash $
 pip install flytekit scikit-learn
 ```


### PR DESCRIPTION
flytekit 1.5.0 is out, which removes this version check.