### PR TITLE
Bigquery docker image

### DIFF
--- a/cookbook/integrations/gcp/bigquery/Dockerfile
+++ b/cookbook/integrations/gcp/bigquery/Dockerfile
@@ -7,8 +7,7 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV PYTHONPATH /root
 
-# This is necessary for opencv to work
-RUN apt-get update && apt-get install -y libsm6 libxext6 libxrender-dev ffmpeg build-essential curl
+RUN apt-get update && apt-get install -y build-essential curl
 
 WORKDIR /opt
 RUN curl https://sdk.cloud.google.com > install.sh

--- a/cookbook/integrations/gcp/bigquery/Dockerfile
+++ b/cookbook/integrations/gcp/bigquery/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.8-slim-buster
+LABEL org.opencontainers.image.source https://github.com/flyteorg/flytesnacks
+
+WORKDIR /root
+ENV VENV /opt/venv
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV PYTHONPATH /root
+
+# This is necessary for opencv to work
+RUN apt-get update && apt-get install -y libsm6 libxext6 libxrender-dev ffmpeg build-essential curl
+
+WORKDIR /opt
+RUN curl https://sdk.cloud.google.com > install.sh
+RUN bash /opt/install.sh --install-dir=/opt
+ENV PATH $PATH:/opt/google-cloud-sdk/bin
+WORKDIR /root
+
+ENV VENV /opt/venv
+# Virtual environment
+RUN python3 -m venv ${VENV}
+ENV PATH="${VENV}/bin:$PATH"
+
+# Install Python dependencies
+COPY bigquery/requirements.txt /root
+RUN pip install -r /root/requirements.txt
+
+# Copy the makefile targets to expose on the container. This makes it easier to register
+COPY in_container.mk /root/Makefile
+COPY bigquery/sandbox.config /root
+
+# Copy the actual code
+COPY bigquery/ /root/bigquery
+
+# This tag is supplied by the build script and will be used to determine the version
+# when registering tasks, workflows, and launch plans
+ARG tag
+ENV FLYTE_INTERNAL_IMAGE $tag

--- a/cookbook/integrations/gcp/bigquery/Makefile
+++ b/cookbook/integrations/gcp/bigquery/Makefile
@@ -2,17 +2,3 @@ PREFIX=bigquery
 include ../../../common/common.mk
 include ../../../common/leaf.mk
 
-.PHONY: docker_build
-docker_build: ;
-
-.PHONY: docker_push
-docker_push: ;
-
-.PHONY: register
-register: ;
-
-.PHONY: serialize
-serialize: ;
-
-.PHONY: docker_push
-docker_push: ;

--- a/cookbook/integrations/gcp/bigquery/bigquery.py
+++ b/cookbook/integrations/gcp/bigquery/bigquery.py
@@ -20,7 +20,7 @@ bigquery_task_no_io = BigQueryTask(
     name="sql.bigquery.no_io",
     inputs={},
     query_template="SELECT 1",
-    task_config=BigQueryConfig(ProjectID="flyte", Location="us-west1-b"),
+    task_config=BigQueryConfig(ProjectID="flyte"),
 )
 
 
@@ -46,8 +46,8 @@ bigquery_task_templatized_query = BigQueryTask(
     # Define inputs as well as their types that can be used to customize the query.
     inputs=kwtypes(version=int),
     output_structured_dataset_type=DogeCoinDataset,
-    task_config=BigQueryConfig(ProjectID="flyte", Location="us-west1-b"),
-    query_template="SELECT * FROM `bigquery-public-data.crypto_dogecoin.transactions` WHERE @version = 1 LIMIT 10;",
+    task_config=BigQueryConfig(ProjectID="flyte"),
+    query_template="SELECT * FROM `bigquery-public-data.crypto_dogecoin.transactions` WHERE version = 1 LIMIT 10;",
 )
 
 


### PR DESCRIPTION

Adds Bigquery Docker file which would now support publishing the bigquery examples in flytesnacks releases.
Currently they are not being published

Also removed the location  which causes error when looking up the job
```
flytepropeller-0 flytepropeller {"json":{"routine":"external-plugin-service-worker-6","src":"cache.go:104"},"level":"info","msg":"Error retrieving resource [ad2th8cwhkl69rwk42sd-n0-0]. Error: rpc error: code = Internal desc = failed to get task with error 404 GET https://bigquery.googleapis.com/bigquery/v2/projects/dogfood-gcp-dataplane/jobs/a8f7fde4-a0e0-410a-b171-ba97c60f65a0?projection=full\u0026prettyPrint=false: Not found: Job dogfood-gcp-dataplane:a8f7fde4-a0e0-410a-b171-ba97c60f65a0","ts":"2023-06-06T20:10:21Z"}
```

It seems bigquery server job creation and get api's are in disconnect with passing the location.
Using the default location instead which is configured for the passed in project

Tested on an internal tenant
![Screenshot 2023-06-06 at 11 58 07 AM](https://github.com/flyteorg/flytesnacks/assets/77798312/8127db42-e162-4887-a0ed-780834b01151)

fixes https://github.com/flyteorg/flyte/issues/3751
