### PR TITLE
Reference new kubeflow training operator instead of deprecated pytorch operator

### DIFF
--- a/cookbook/integrations/kubernetes/kfpytorch/pytorch_mnist.py
+++ b/cookbook/integrations/kubernetes/kfpytorch/pytorch_mnist.py
@@ -2,9 +2,11 @@
 Distributed Pytorch
 -------------------
 
-This example is adapted from the default example available on Kubeflow's pytorch site.
-`here <https://github.com/kubeflow/pytorch-operator/blob/b7fef224fef1ef0117f6e74961b557270fcf4b04/examples/mnist/mnist.py>`_
-It has been modified to show how to integrate it with Flyte and can be probably simplified and cleaned up.
+This example is adapted from the default example available on Kubeflow's pytorch site
+`here <https://github.com/kubeflow/pytorch-operator/blob/b7fef224fef1ef0117f6e74961b557270fcf4b04/examples/mnist/mnist.py>`_.
+(The kubeflow pytorch operator has been deprecated in favor of the new `kubeflow training operator <https://github.com/kubeflow/training-operator>`_
+which can simply be deployed instead of the pytorch operator in a Flyte cluster.)
+The example has been modified to show how to integrate it with Flyte and can be probably simplified and cleaned up.
 
 """
 import os


### PR DESCRIPTION
The kubeflow pytorch operator has been replaced by the new training operator which bundles the operators for pytorch, tensorflow, ... into a single one.

The pytorch flytesnacks example points to the deprecated pytorch operator repository which might confuse users, see e.g. [here](https://flyte-org.slack.com/archives/CP2HDHKE1/p1686329241467869).

This PR adapts the example to reference the new training operator additionally in order to not make users think the underlying operator is not maintained anymore.

I still left the link to the original repository in the docs, despite the repo's deprecation, since the example in the new repository doesn't use Mnist but FashionMnist.