### PR TITLE
Fix "ray: command not found Error" with Kuberay v0.3.0+

### DIFF
--- a/cookbook/integrations/kubernetes/ray_example/Dockerfile
+++ b/cookbook/integrations/kubernetes/ray_example/Dockerfile
@@ -18,11 +18,6 @@ RUN bash /opt/install.sh --install-dir=/opt
 ENV PATH $PATH:/opt/google-cloud-sdk/bin
 WORKDIR /root
 
-ENV VENV /opt/venv
-# Virtual environment
-RUN python3 -m venv ${VENV}
-ENV PATH="${VENV}/bin:$PATH"
-
 # Install Python dependencies
 COPY ray_example/requirements.txt /root
 RUN pip install -r /root/requirements.txt


### PR DESCRIPTION
Recent updates to Kuberay (versions beyond 0.3.0) have been causing a `/bin/bash: ray: command not found` error when users attempt to create rayjobs through Flyte.

#### Why does this result in a `/bin/bash: ray: command not found` error?
1. The Dockerfile adds `/opt/venv` to `PATH` using `ENV PATH="${VENV}/bin:$PATH"`, rather than writing it into files like `.bashrc`. Thus, if a new shell is initiated and reads files like `.bashrc` first, `$PATH` may get overridden. The recent modifications to Kuberay initiate such a shell and thus override the `PATH` (see [this PR](https://github.com/ray-project/kuberay/pull/427) for more details), causing the `/opt/venv` directory not to be included in the `PATH`.

#### How to resolve this?
This issue can be addressed by eliminating the redundant Python3 virtual environment. Given that the base image is `python:3.8-slim-buster`, there's no need to establish an additional Python virtual environment in the `/opt/venv` directory, nor is there a need to add `/opt/venv` to `PATH`.
