### PR TITLE
Using the auto config loader for flyteremote example

### DIFF
--- a/cookbook/remote_access/remote_launchplan.py
+++ b/cookbook/remote_access/remote_launchplan.py
@@ -43,7 +43,7 @@ A launch plan can be launched via FlyteRemote programmatically.
 
     # FlyteRemote object is the main entrypoint to API
     remote = FlyteRemote(
-        config=Config.for_endpoint(endpoint="flyte.example.net"),
+        config=Config.auto(),
         default_project="flytesnacks",
         default_domain="development",
     )


### PR DESCRIPTION
Currently the example tries to construct a config providing the endpoint name in flyte remote.
Instead it can directly rely on the config already used by flytekit, flytectl eg : ~/.flyte/config.yaml
which already knows how to connect to the flyte endpoint.




Tested using the following example
```
from flytekit.remote import FlyteRemote
from flytekit.configuration import Config
from flytekit import LaunchPlan
from flytekit.configuration import get_config_file

# FlyteRemote object is the main entrypoint to API
remote = FlyteRemote(
    config=Config.auto(),
    default_project="flytesnacks",
    default_domain="development",
)

# Fetch launch plan
flyte_lp = remote.fetch_launch_plan(
    name="core.flyte_basics.lp.go_greet", version="v0.3.203", project="flytesnacks", domain="development"
)

# Execute
execution = remote.execute(
    flyte_lp, inputs={"day_of_week": "Sun", "number": 1}, execution_name="executionname", wait=True
```