### PR TITLE
add a note specifying the supported kuberay version

### DIFF
--- a/examples/ray_plugin/README.md
+++ b/examples/ray_plugin/README.md
@@ -3,6 +3,7 @@
 # KubeRay
 
 ```{tags} Integration, DistributedComputing, KubernetesOperator, Advanced
+
 ```
 
 ```{image} https://img.shields.io/badge/Blog-Ray-blue?style=for-the-badge
@@ -10,12 +11,12 @@
 :alt: Ray Blog Post
 ```
 
-[KubeRay](https://github.com/ray-project/kuberay) is an open source toolkit to run Ray applications on Kubernetes. It provides tools to improve running and managing Ray on Kubernetes.
+[KubeRay](https://github.com/ray-project/kuberay) is an open-source toolkit designed for running Ray applications on Kubernetes. It offers various tools to enhance the execution and management of Ray on Kubernetes.
 
 - Ray Operator
-- Backend services to create/delete cluster resources
-- Kubectl plugin/CLI to operate CRD objects
-- Native Job and Serving integration with Clusters
+- Backend services for creating and deleting cluster resources
+- Kubectl plugin/CLI for interacting with CRD objects
+- Native integration with Clusters for Job and Serving functionalities
 
 ## Installation
 
@@ -25,9 +26,12 @@ To install the Ray plugin, run the following command:
 pip install flytekitplugins-ray
 ```
 
-To enable the plugin in the backend, follow instructions outlined in the {std:ref}`flyte:deployment-plugin-setup-k8s` guide.
+To enable the plugin in the backend, refer to the instructions provided in the {std:ref}`flyte:deployment-plugin-setup-k8s` guide.
 
-### Submit a Ray Job to Existing Cluster
+Here are two quick examples that give you an overview of the integration.
+If you're interested in a more detailed exploration, please refer to the example page for further details.
+
+### Submitting a Ray job to an existing cluster
 
 ```{eval-rst}
 .. testcode:: ray-quickstart-1
@@ -49,7 +53,7 @@ To enable the plugin in the backend, follow instructions outlined in the {std:re
 
 ```
 
-### Create a Ray Cluster Managed by Flyte and Run a Ray Job on This Cluster
+### Creating a Ray cluster managed by Flyte and running a Ray job on it
 
 ```{eval-rst}
 .. testcode:: ray-quickstart-2


### PR DESCRIPTION
This PR adds a note to the kuberay docs specifying the version supported by the plugin.

Fixes https://github.com/flyteorg/flyte/issues/3763