### PR TITLE
Add a comma for syntax error in launch_plan

### DIFF
--- a/docs/getting_started/run_schedule.md
+++ b/docs/getting_started/run_schedule.md
@@ -219,7 +219,7 @@ launch_plan = LaunchPlan.get_or_create(
     wf,
     name="wf_launchplan",
     # run this launchplan every minute
-    schedule=CronSchedule(schedule="*/1 * * * *")
+    schedule=CronSchedule(schedule="*/1 * * * *"),
     default_inputs={"name": "Elmo"},
 )
 ```


### PR DESCRIPTION
We should add a comman after "schedule=CronSchedule(schedule="*/1 * * * *")"