### PR TITLE
Fix merge sort error

### DIFF
--- a/docs/getting_started/run_schedule.md
+++ b/docs/getting_started/run_schedule.md
@@ -50,7 +50,11 @@ object:
 from flytekit.remote import FlyteRemote
 from flytekit.configuration import Config
 
-remote = FlyteRemote(config=Config.auto())
+remote = FlyteRemote(
+    config=Config.auto(),
+    default_project="flytesnacks",
+    default_domain="development",
+)
 ```
 
 ## Running a Workflow
@@ -58,6 +62,11 @@ remote = FlyteRemote(config=Config.auto())
 You can run workflows using the `FlyteRemote` {py:meth}`~flytekit.remote.remote.FlyteRemote.execute`
 method, where you need to pass in a dictionary of `inputs` that adhere to the
 interface defined by the workflow.
+The Image below here has include workflows directory from 
+```{prompt} bash $
+pyflyte init my_project
+```
+and build the docker image from the DockerFile in the directory.
 
 `````{tabs}
 
@@ -70,7 +79,10 @@ environment, you can import and execute it directly:
 
 from workflows.example import wf
 
-execution = remote.execute(wf, inputs={"name": "Kermit"})
+execution = remote.execute(wf,
+    inputs={"name": "Kermit"},
+    image_config=ImageConfig.auto(img_name="futureoutlier/flyte-practice:latest"),
+)
 ```
 
 ````

--- a/examples/control_flow/control_flow/merge_sort.py
+++ b/examples/control_flow/control_flow/merge_sort.py
@@ -36,7 +36,7 @@ def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int]
         numbers[0 : int(len(numbers) / 2)],
         numbers[int(len(numbers) / 2) :],
         int(len(numbers) / 2),
-        int(len(numbers)) - int(len(numbers) / 2)
+        int(len(numbers)) - int(len(numbers) / 2),
     )
 
 

--- a/examples/control_flow/control_flow/merge_sort.py
+++ b/examples/control_flow/control_flow/merge_sort.py
@@ -36,7 +36,7 @@ def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int]
         numbers[0 : int(len(numbers) / 2)],
         numbers[int(len(numbers) / 2) :],
         int(len(numbers) / 2),
-        len(numbers) - int(len(numbers) / 2)
+        int(len(numbers)) - int(len(numbers) / 2)
     )
 
 

--- a/examples/control_flow/control_flow/merge_sort.py
+++ b/examples/control_flow/control_flow/merge_sort.py
@@ -82,7 +82,7 @@ def sort_locally(numbers: typing.List[int]) -> typing.List[int]:
 def merge_sort_remotely(numbers: typing.List[int], run_local_at_count: int) -> typing.List[int]:
     split1, split2, new_count = split(numbers=numbers)
     sorted1 = merge_sort(numbers=split1, numbers_count=new_count, run_local_at_count=run_local_at_count)
-    sorted2 = merge_sort(numbers=split2, numbers_count=new_count, run_local_at_count=run_local_at_count)
+    sorted2 = merge_sort(numbers=split2, numbers_count=len(numbers) - new_count, run_local_at_count=run_local_at_count)
     return merge(sorted_list1=sorted1, sorted_list2=sorted2)
 
 

--- a/examples/control_flow/control_flow/merge_sort.py
+++ b/examples/control_flow/control_flow/merge_sort.py
@@ -31,11 +31,12 @@ seed(datetime.now().microsecond)
 
 # %%
 @task
-def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int], int]:
+def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int], int, int]:
     return (
         numbers[0 : int(len(numbers) / 2)],
         numbers[int(len(numbers) / 2) :],
         int(len(numbers) / 2),
+        len(numbers) - int(len(numbers) / 2)
     )
 
 
@@ -80,9 +81,9 @@ def sort_locally(numbers: typing.List[int]) -> typing.List[int]:
 # %%
 @dynamic
 def merge_sort_remotely(numbers: typing.List[int], run_local_at_count: int) -> typing.List[int]:
-    split1, split2, new_count = split(numbers=numbers)
-    sorted1 = merge_sort(numbers=split1, numbers_count=new_count, run_local_at_count=run_local_at_count)
-    sorted2 = merge_sort(numbers=split2, numbers_count=len(numbers) - new_count, run_local_at_count=run_local_at_count)
+    split1, split2, new_count1, new_count2 = split(numbers=numbers)
+    sorted1 = merge_sort(numbers=split1, numbers_count=new_count1, run_local_at_count=run_local_at_count)
+    sorted2 = merge_sort(numbers=split2, numbers_count=new_count2, run_local_at_count=run_local_at_count)
     return merge(sorted_list1=sorted1, sorted_list2=sorted2)
 
 

--- a/examples/control_flow/control_flow/merge_sort.py
+++ b/examples/control_flow/control_flow/merge_sort.py
@@ -31,11 +31,12 @@ seed(datetime.now().microsecond)
 
 # %%
 @task
-def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int], int]:
+def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int], int, int]:
     return (
         numbers[0 : int(len(numbers) / 2)],
         numbers[int(len(numbers) / 2) :],
         int(len(numbers) / 2),
+        int(len(numbers)) - int(len(numbers) / 2),
     )
 
 
@@ -80,9 +81,9 @@ def sort_locally(numbers: typing.List[int]) -> typing.List[int]:
 # %%
 @dynamic
 def merge_sort_remotely(numbers: typing.List[int], run_local_at_count: int) -> typing.List[int]:
-    split1, split2, new_count = split(numbers=numbers)
-    sorted1 = merge_sort(numbers=split1, numbers_count=new_count, run_local_at_count=run_local_at_count)
-    sorted2 = merge_sort(numbers=split2, numbers_count=new_count, run_local_at_count=run_local_at_count)
+    split1, split2, new_count1, new_count2 = split(numbers=numbers)
+    sorted1 = merge_sort(numbers=split1, numbers_count=new_count1, run_local_at_count=run_local_at_count)
+    sorted2 = merge_sort(numbers=split2, numbers_count=new_count2, run_local_at_count=run_local_at_count)
     return merge(sorted_list1=sorted1, sorted_list2=sorted2)
 
 

--- a/examples/control_flow/control_flow/merge_sort.py
+++ b/examples/control_flow/control_flow/merge_sort.py
@@ -31,12 +31,11 @@ seed(datetime.now().microsecond)
 
 # %%
 @task
-def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int], int, int]:
+def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int], int]:
     return (
         numbers[0 : int(len(numbers) / 2)],
         numbers[int(len(numbers) / 2) :],
         int(len(numbers) / 2),
-        int(len(numbers)) - int(len(numbers) / 2),
     )
 
 
@@ -81,9 +80,9 @@ def sort_locally(numbers: typing.List[int]) -> typing.List[int]:
 # %%
 @dynamic
 def merge_sort_remotely(numbers: typing.List[int], run_local_at_count: int) -> typing.List[int]:
-    split1, split2, new_count1, new_count2 = split(numbers=numbers)
-    sorted1 = merge_sort(numbers=split1, numbers_count=new_count1, run_local_at_count=run_local_at_count)
-    sorted2 = merge_sort(numbers=split2, numbers_count=new_count2, run_local_at_count=run_local_at_count)
+    split1, split2, new_count = split(numbers=numbers)
+    sorted1 = merge_sort(numbers=split1, numbers_count=new_count, run_local_at_count=run_local_at_count)
+    sorted2 = merge_sort(numbers=split2, numbers_count=new_count, run_local_at_count=run_local_at_count)
     return merge(sorted_list1=sorted1, sorted_list2=sorted2)
 
 


### PR DESCRIPTION
Hello, reviewers
When the input list is of size run_local_at_count * 2 + 1, it should ideally be divided into two sublists:

Sublist 1: length = **run_local_at_count**, should be processed by **sort_locally**.
Sublist 2: length = run_local_at_count + 1, should be processed by **merge_sort_remotely**.

However, due to an error in the splitting function, both sublists are processed with **sort_locally**, which deviates from the intended behavior of the algorithm. While the final sorted output is still correct, it's crucial that the second sublist, given its length, is processed with **merge_sort_remotely** to follow the algorithm's original design.

PS: I forget to use master branch to commit this file so I create this pull request again.