### PR TITLE
Update dockerfile in k8s_spark_plugin

### DIFF
--- a/examples/k8s_spark_plugin/Dockerfile
+++ b/examples/k8s_spark_plugin/Dockerfile
@@ -44,10 +44,6 @@ COPY . /root/
 ARG tag
 ENV FLYTE_INTERNAL_IMAGE $tag
 
-# Copy over the helper script that the SDK relies on
-RUN cp ${VENV}/bin/flytekit_venv /usr/local/bin/
-RUN chmod a+x /usr/local/bin/flytekit_venv
-
 # Set /root user and group
 RUN chown -R ${spark_uid}:${spark_uid} /root
 


### PR DESCRIPTION
We don't necessarily need to copy flytekit_venv to `/usr/local/bin/`