### PR TITLE
use eval-rst for tags to prevent showing up on sidebar

### DIFF
--- a/examples/advanced_composition/advanced_composition/map_task.py
+++ b/examples/advanced_composition/advanced_composition/map_task.py
@@ -3,7 +3,8 @@
 #
 # # Map Tasks
 #
-# ```{tags} Intermediate
+# ```{eval-rst}
+# .. tags:: Intermediate
 # ```
 #
 # ```{image} https://img.shields.io/badge/Blog%20Post-Map%20Tasks-blue?style=for-the-badge

--- a/examples/blast/README.md
+++ b/examples/blast/README.md
@@ -2,7 +2,8 @@
 
 # Nucleotide Sequence Querying with BLASTX
 
-```{tags} Advanced
+```{eval-rst}
+.. tags:: Advanced
 ```
 
 This tutorial demonstrates the integration of computational biology and Flyte.

--- a/examples/exploratory_data_analysis/README.md
+++ b/examples/exploratory_data_analysis/README.md
@@ -1,6 +1,7 @@
 # EDA, Feature Engineering, and Modeling With Papermill
 
-```{tags} Data, Jupyter, Intermediate
+```{eval-rst}
+.. tags:: Data, Jupyter, Intermediate
 ```
 
 Exploratory Data Analysis (EDA) refers to the critical process of performing initial investigations on data to discover patterns,

--- a/examples/feast_integration/README.md
+++ b/examples/feast_integration/README.md
@@ -1,6 +1,7 @@
 # Feast Integration
 
-```{tags} Data, MachineLearning, Advanced
+```{eval-rst}
+.. tags:: Data, MachineLearning, Advanced
 ```
 
 ```{image} https://img.shields.io/badge/Blog-Feast%20Integration-blue?style=for-the-badge

--- a/examples/forecasting_sales/README.md
+++ b/examples/forecasting_sales/README.md
@@ -2,7 +2,8 @@
 
 # Forecasting Rossman Store Sales with Horovod and Spark
 
-```{tags} MachineLearning, Integration, Advanced
+```{eval-rst}
+.. tags:: MachineLearning, Integration, Advanced
 ```
 
 ```{image} https://img.shields.io/badge/Blog-Horovod%20and%20Spark-blue?style=for-the-badge

--- a/examples/house_price_prediction/README.md
+++ b/examples/house_price_prediction/README.md
@@ -1,6 +1,7 @@
 # House Price Regression
 
-```{tags} Data, MachineLearning, DataFrame, Intermediate
+```{eval-rst}
+.. tags:: Data, MachineLearning, DataFrame, Intermediate
 ```
 
 House Price Regression refers to the prediction of house prices based on various factors, using the XGBoost Regression model (in our case).

--- a/examples/mnist_classifier/README.md
+++ b/examples/mnist_classifier/README.md
@@ -2,7 +2,8 @@
 
 # MNIST Classification With PyTorch and W&B
 
-```{tags} MachineLearning, GPU, Advanced
+```{eval-rst}
+.. tags:: MachineLearning, GPU, Advanced
 ```
 
 ## PyTorch

--- a/examples/nlp_processing/README.md
+++ b/examples/nlp_processing/README.md
@@ -1,6 +1,7 @@
 # NLP Processing
 
-```{tags} MachineLearning, UI, Intermediate
+```{eval-rst}
+.. tags:: MachineLearning, UI, Intermediate
 ```
 
 This tutorial will demonstrate how to process text data and generate word embeddings and visualizations

--- a/examples/pima_diabetes/README.md
+++ b/examples/pima_diabetes/README.md
@@ -1,6 +1,7 @@
 # Diabetes Classification
 
-```{tags} MachineLearning, Intermediate
+```{eval-rst}
+.. tags:: MachineLearning, Intermediate
 ```
 
 The workflow demonstrates how to train an XGBoost model. The workflow is designed for the [Pima Indian Diabetes dataset](https://github.com/jbrownlee/Datasets/blob/master/pima-indians-diabetes.names).


### PR DESCRIPTION
Using the `eval-rst` directive prevents tags with the same name as pages will prevent the `Example Tags` sidebar from showing up:
<img width="381" alt="image" src="https://github.com/flyteorg/flytesnacks/assets/2816689/98aef401-63f1-466f-826c-0e0f7c7f3b16">
