### PR TITLE
Fix "Hello World" Flytekit Tutorial Code

### DIFF
--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -24,7 +24,7 @@ def hello_world_wf() -> str:
     return res
 
 if __name__ == "__main__":
-    print(f"Running my_wf() {my_wf()}")
+    print(f"Running hello_world_wf() {hello_world_wf()}")
 ```
 
 To install `flytekit`, run the following command:
@@ -53,7 +53,7 @@ python hello_world.py
 Expected output:
 
 ```{prompt}
-Running my_wf() hello world
+Running hello_world_wf() Hello, World!
 ```
 
 ## Create a local demo Flyte cluster


### PR DESCRIPTION
# Description

This PR addresses an issue in the "Hello World" tutorial for Flytekit:

The workflow was named `hello_world_wf`, but the main execution block tried to run an undeclared `my_wf()`. 
This has been corrected to run `hello_world_wf()`.

With this corrections, the tutorial code now runs successfully.

# Changes
- Fixed the name mismatch in the main execution block.

# Testing
Ensure the tutorial runs without any issues after applying these changes.

```bash
python hello_world.py
╭─ Traceback (most recent call ─╮
│ /Users/flytectl/docs/ │
│ hello_world.py:13 in <module> │
│                               │
│ ❱ 13 │   print(f"Running my_w │
╰───────────────────────────────╯
NameError: name 'my_wf' is not 
```
