### PR TITLE
fix workflow function name

### DIFF
--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -24,7 +24,7 @@ def hello_world_wf() -> str:
     return res
 
 if __name__ == "__main__":
-    print(f"Running my_wf() {my_wf()}")
+    print(f"Running hello_world_wf() {hello_world_wf()}")
 ```
 
 To install `flytekit`, run the following command:


### PR DESCRIPTION
The first code snippet in the "Environment setup" user guide calls and undefined function:

```python
from flytekit import task, workflow

@task
def say_hello() -> str:
    return "Hello, World!"

@workflow
def hello_world_wf() -> str:
    res = say_hello()
    return res

if __name__ == "__main__":
    print(f"Running my_wf() {my_wf()}")
```

```
> python hello_world.py
```
```
╭─────────────────────────────────────────────────────────────────────────── Traceback (most recent call last) ───────────────────────────────────────────────────────────────────────────╮
│ <path>/hello_world.py:16 in <module>                                                                                                                         │
│                                                                                                                                                                                         │
│ ❱ 16 │   print(f"Running my_wf() {my_wf()}")                                                                                                                                            │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
NameError: name 'my_wf' is not defined
```

This PR fixes the above issue.