### PR TITLE
Simplify chain_entities example

### DIFF
--- a/examples/advanced_composition/advanced_composition/chain_entities.py
+++ b/examples/advanced_composition/advanced_composition/chain_entities.py
@@ -7,101 +7,41 @@
 # .. tags:: Basic
 # ```
 #
-# Data passing between tasks or workflows need not necessarily happen through parameters.
-# In such a case, if you want to explicitly construct the dependency, flytekit provides a mechanism to chain Flyte entities using the `>>` operator.
+# flytekit provides a mechanism to chain Flyte entities using the `>>` operator.
 #
 # ## Tasks
 #
-# Let's enforce an order for `read()` to happen after `write()`, and for `write()` to happen after `create_bucket()`.
+# Let's enforce an order for `t1()` to happen after `t0()`, and for `t2()` to happen after `t1()`.
 #
-# :::{note}
-# To run the example locally, spin up the demo cluster using `flytectl demo start`.
-# :::
-
-# %% [markdown]
 # Import the necessary dependencies.
 # %%
-import logging
-from io import StringIO
-
-import pandas as pd
-from botocore import session
 from flytekit import task, workflow
-from flytekit.configuration import S3Config
-
-logger = logging.getLogger(__file__)
-
-CSV_FILE = "iris.csv"
-BUCKET_NAME = "chain-flyte-entities"
 
 
-def s3_client():
-    cfg = S3Config.auto()
-    sess = session.get_session()
-    return sess.create_client(
-        "s3",
-        aws_access_key_id=cfg.access_key_id,
-        aws_secret_access_key=cfg.secret_access_key,
-        use_ssl=False,
-        endpoint_url=cfg.endpoint,
-    )
-
-
-# %% [markdown]
-# Create an s3 bucket.
-# This task exists just for the sandbox case.
-# %%
-@task(cache=True, cache_version="1.0")
-def create_bucket():
-    client = s3_client()
-    try:
-        client.create_bucket(Bucket=BUCKET_NAME)
-    except client.exceptions.BucketAlreadyOwnedByYou:
-        logger.info(f"Bucket {BUCKET_NAME} has already been created by you.")
-
-
-# %% [markdown]
-# Define a `read()` task to read from the s3 bucket.
-# %%
 @task
-def read() -> pd.DataFrame:
-    data = pd.read_csv(s3_client().get_object(Bucket=BUCKET_NAME, Key=CSV_FILE)["Body"])
-    return data
+def t2():
+    pass   
+
+@task
+def t1():
+    pass   
+
+@task
+def t0():
+    pass
 
 
 # %% [markdown]
-# Define a `write()` task to write the dataframe to a CSV file in the s3 bucket.
-# %%
-@task(cache=True, cache_version="1.0")
-def write():
-    df = pd.DataFrame(  # noqa : F841
-        data={
-            "sepal_length": [5.3],
-            "sepal_width": [3.8],
-            "petal_length": [0.1],
-            "petal_width": [0.3],
-            "species": ["setosa"],
-        }
-    )
-    csv_buffer = StringIO()
-    df.to_csv(csv_buffer)
-    s3_client().put_object(Body=csv_buffer.getvalue(), Bucket=BUCKET_NAME, Key=CSV_FILE)
-
-
-# %% [markdown]
-# We want to enforce an order here: `create_bucket()` followed by `write()` followed by `read()`.
-# Since no data-passing happens between the tasks, use `>>` operator on the tasks.
+# We want to enforce an order here: `t0()` followed by `t1()` followed by `t2()`.
 # %%
 @workflow
-def chain_tasks_wf() -> pd.DataFrame:
-    create_bucket_promise = create_bucket()
-    write_promise = write()
-    read_promise = read()
+def chain_tasks_wf():
+    t2_promise = t2()
+    t1_promise = t1()
+    t0_promise = t0()
 
-    create_bucket_promise >> write_promise
-    write_promise >> read_promise
-
-    return read_promise
+    t0_promise >> t1_promise
+    t1_promise >> t2_promise
 
 
 # %% [markdown]
@@ -110,28 +50,24 @@ def chain_tasks_wf() -> pd.DataFrame:
 # Similar to tasks, you can chain {ref}`subworkflows <subworkflows>`.
 # %%
 @workflow
-def write_sub_workflow():
-    write()
+def sub_workflow_1():
+    t1()
 
 
 @workflow
-def read_sub_workflow() -> pd.DataFrame:
-    return read()
+def sub_workflow_0():
+    t0()
 
 
 # %% [markdown]
 # Use `>>` to chain the subworkflows.
 # %%
 @workflow
-def chain_workflows_wf() -> pd.DataFrame:
-    create_bucket_promise = create_bucket()
-    write_sub_wf = write_sub_workflow()
-    read_sub_wf = read_sub_workflow()
+def chain_workflows_wf():
+    sub_wf1 = sub_workflow_1()
+    sub_wf0 = sub_workflow_0()
 
-    create_bucket_promise >> write_sub_wf
-    write_sub_wf >> read_sub_wf
-
-    return read_sub_wf
+    sub_wf0 >> sub_wf1
 
 
 # %% [markdown]

--- a/examples/advanced_composition/advanced_composition/chain_entities.py
+++ b/examples/advanced_composition/advanced_composition/chain_entities.py
@@ -20,11 +20,13 @@ from flytekit import task, workflow
 
 @task
 def t2():
-    pass   
+    pass
+
 
 @task
 def t1():
-    pass   
+    pass
+
 
 @task
 def t0():


### PR DESCRIPTION
`chain_entities.py` should only demonstrate how to chain Flyte entities without the need for permissions to write to an s3 bucket. 

This has the benefits of not only simplifying the actual feature (since we won't need to worry about extraneous details like creating s3 buckets) and allowing for this code to be executed in a functional test in any Flyte cluster.