### PR TITLE
Fixes link in Flyte and Python Types docs

### DIFF
--- a/examples/data_types_and_io/data_types_and_io/flyte_python_types.py
+++ b/examples/data_types_and_io/data_types_and_io/flyte_python_types.py
@@ -96,6 +96,6 @@
 #    * - User defined types
 #      - Any
 #      - Custom Transformers
-#      - Use python 3 type hints. We use ``FlytePickle transformer`` by default, but users still can provide custom transformers. Refer to {ref}`advanced_custom_types`.
+#      - Use python 3 type hints. We use ``FlytePickle transformer`` by default, but users still can provide custom transformers. Refer to :ref:`advanced_custom_types`.
 # ```
 #


### PR DESCRIPTION
This PR fixes the link in the "Flyte and Python Types" docs. The code block uses `{eval-rst}`:

https://github.com/flyteorg/flytesnacks/blob/8b0c61e6615a8f94cb859c44c05ee1563db5d2a0/examples/data_types_and_io/data_types_and_io/flyte_python_types.py#L15-L17

which means we need to use normal `rst` syntax to link to other pages. 