### PR TITLE
Replaced every instance of dataclass_json with the updated mashumaro mixin

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -114,7 +114,7 @@ flake8-isort==6.0.0
     # via -r dev-requirements.in
 flyteidl==1.5.16
     # via flytekit
-flytekit==1.9.0
+flytekit==1.10.0
     # via -r dev-requirements.in
 frozenlist==1.4.0
     # via

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -152,7 +152,7 @@ flyteidl==1.5.16
     # via
     #   flytekit
     #   flytekitplugins-kfpytorch
-flytekit==1.9.0
+flytekit==1.10.0
     # via
     #   -r docs-requirements.in
     #   flytekitplugins-deck-standard

--- a/docs/getting_started/extending_flyte.md
+++ b/docs/getting_started/extending_flyte.md
@@ -45,12 +45,10 @@ metadata:
 import typing
 
 from dataclasses import dataclass
-from dataclasses_json import dataclass_json
+from mashumaro.mixins.json import DataClassJSONMixin
 
-
-@dataclass_json
 @dataclass
-class Coordinate:
+class Coordinate(DataClassJSONMixin):
     """A custom type for coordinates with metadata attached."""
     x: float
     y: float

--- a/examples/data_types_and_io/data_types_and_io/custom_objects.py
+++ b/examples/data_types_and_io/data_types_and_io/custom_objects.py
@@ -10,12 +10,17 @@
 # Flyte supports passing JSON between tasks. But to simplify the usage for the users and introduce type-safety,
 # Flytekit supports passing custom data objects between tasks.
 #
-# Currently, data classes decorated with `@dataclass_json` are supported.
+# Currently, data classes inheriting DataClassJSONMixin are supported.
 # One good use case of a data class would be when you want to wrap all input in a data class in the case of a map task
 # which can only accept one input and produce one output.
 #
 # This example shows how users can serialize custom JSON-compatible dataclasses between successive tasks using the
-# excellent [dataclasses_json](https://pypi.org/project/dataclasses-json/) library.
+# excellent [mashumaro](https://github.com/Fatal1ty/mashumaro) library.
+#
+# :::{note}
+# Please note that if you are below Flytekit v1.10 you'll need to also decorate with @dataclass_json via 
+# `from dataclass_json import dataclass_json` instead of Mashumaro's DataClassJSONMixin.
+# :::
 
 # %% [markdown]
 # To get started, let's import the necessary libraries.
@@ -26,7 +31,7 @@ import typing
 from dataclasses import dataclass
 
 import pandas as pd
-from dataclasses_json import dataclass_json
+from mashumaro.mixins.json import DataClassJSONMixin
 from flytekit import task, workflow
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
@@ -36,9 +41,8 @@ from flytekit.types.schema import FlyteSchema
 # %% [markdown]
 # We define a simple data class that can be sent between tasks.
 # %%
-@dataclass_json
 @dataclass
-class Datum(object):
+class Datum(DataClassJSONMixin):
     """
     Example of a simple custom class that is modeled as a dataclass
     """
@@ -60,9 +64,8 @@ class Datum(object):
 # Next, we define a data class that accepts {std:ref}`FlyteSchema <typed_schema>`, {std:ref}`FlyteFile <files>`,
 # and {std:ref}`FlyteDirectory <folders>`.
 # %%
-@dataclass_json
 @dataclass
-class Result:
+class Result(DataClassJSONMixin):
     schema: FlyteSchema
     file: FlyteFile
     directory: FlyteDirectory

--- a/examples/data_types_and_io/data_types_and_io/flyte_python_types.py
+++ b/examples/data_types_and_io/data_types_and_io/flyte_python_types.py
@@ -80,7 +80,7 @@
 #    * - Dataclasses ``@dataclass``
 #      - Struct
 #      - Automatic
-#      - Use python 3 type hints. The class should be a pure value class and should be annotated with ``@dataclass and @dataclass_json``.
+#      - Use python 3 type hints. The class should be a pure value class, inherit from Mashumaro's DataClassJSONMixin, and be annotated with ``@dataclass`.
 #    * - pandas.DataFrame
 #      - Schema
 #      - Automatic


### PR DESCRIPTION
This should remove the warning during `pyflyte run` caused by dataclasses not knowing what to do with the Flyte types used in the Result dataclass from the example in the docs