### PR TITLE
Fixes links to basics/{workflow.py, task.py}

### DIFF
--- a/examples/basics/basics/task.py
+++ b/examples/basics/basics/task.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
 # To run it locally, you can use the following `pyflyte run` command:
 # ```
 # pyflyte run \
-#   https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/01_basics/01_basics/task.py \
+#   https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/basics/basics/task.py \
 #   slope --x '[-3,0,3]' --y '[7,4,-2]'
 # ```
 #
@@ -80,6 +80,6 @@ if __name__ == "__main__":
 # simply add the `--remote flag` to the `pyflyte run` command:
 # ```
 # pyflyte run --remote \
-#   https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/01_basics/01_basics/task.py \
+#   https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/basics/basics/task.py \
 #   slope --x '[-3,0,3]' --y '[7,4,-2]'
 # ```

--- a/examples/basics/basics/workflow.py
+++ b/examples/basics/basics/workflow.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
 # To run the workflow locally, you can use the following `pyflyte run` command:
 # ```
 # pyflyte run \
-#   https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/01_basics/01_basics/workflow.py \
+#   https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/basics/basics/workflow.py \
 #   simple_wf --x '[-3,0,3]' --y '[7,4,-2]'
 # ```
 #
@@ -99,7 +99,7 @@ if __name__ == "__main__":
 # simply add the `--remote flag` to the `pyflyte run` command:
 # ```
 # pyflyte run --remote \
-#   https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/01_basics/01_basics/workflow.py \
+#   https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/basics/basics/workflow.py \
 #   simple_wf --x '[-3,0,3]' --y '[7,4,-2]'
 # ```
 #


### PR DESCRIPTION
This PR fixes the links to https://github.com/flyteorg/flytesnacks/blob/master/examples/basics/basics/task.py and https://github.com/flyteorg/flytesnacks/blob/master/examples/basics/basics/workflow.py.