### PR TITLE
Fixes code literals in Flyte and Python Types docs

### DIFF
--- a/examples/data_types_and_io/data_types_and_io/flyte_python_types.py
+++ b/examples/data_types_and_io/data_types_and_io/flyte_python_types.py
@@ -80,7 +80,7 @@
 #    * - Dataclasses ``@dataclass``
 #      - Struct
 #      - Automatic
-#      - Use python 3 type hints. The class should be a pure value class and should be annotated with ``@dataclass and @dataclass_json``.
+#      - Use python 3 type hints. The class should be a pure value class and should be annotated with ``@dataclass`` and ``@dataclass_json``.
 #    * - pandas.DataFrame
 #      - Schema
 #      - Automatic

--- a/examples/data_types_and_io/data_types_and_io/flyte_python_types.py
+++ b/examples/data_types_and_io/data_types_and_io/flyte_python_types.py
@@ -60,7 +60,7 @@
 #    * - Univariate List / typing.List
 #      - Collection [ type ]
 #      - Automatic
-#      - Use python 3 type hints e.g ``typing.List[T], where T can be one of the other supported types in the table``
+#      - Use python 3 type hints e.g ``typing.List[T]``, where ``T`` can be one of the other supported types in the table
 #    * - file / file-like / os.PathLike / flytekit.types.file.FlyteFile
 #      - Blob - Single
 #      - Automatic
@@ -72,7 +72,7 @@
 #    * - Typed dictionary with str key - typing.Dict[str, V]
 #      - Map[str, V]
 #      - Automatic
-#      - Use python 3 type hints e.g ``typing.Dict[str, V], where V can be one of the other supported types in the table even another Dictionary (nested)``
+#      - Use python 3 type hints e.g ``typing.Dict[str, V]``, where V can be one of the other supported types in the table even another Dictionary (nested)
 #    * - Untyped dictionary - dict
 #      - JSON (struct.pb)
 #      - Automatic


### PR DESCRIPTION
This PR adjusts the backticks to wrap the code and not whole sentence.