### PR TITLE
Use pd.concat instead because df.append is deprecated

### DIFF
--- a/examples/data_types_and_io/data_types_and_io/schema.py
+++ b/examples/data_types_and_io/data_types_and_io/schema.py
@@ -44,9 +44,8 @@ def get_df(a: int) -> pandas.DataFrame:
 def add_df(df: pandas.DataFrame) -> pandas.DataFrame:
     """
     Append some data to the dataframe.
-    NOTE: this may result in runtime failures if the columns do not match
     """
-    return df.append(pandas.DataFrame(data={"col1": [5, 10], "col2": [5, 10]}))
+    return pandas.concat([df, pandas.DataFrame(data={"col1": [5, 10], "col2": [5, 10]})])
 
 
 # %% [markdown]


### PR DESCRIPTION
`pd.concat` is deprecated in pandas `1.X` and was removed in `2.0`. XREF: https://github.com/pandas-dev/pandas/issues/35407

`pd.concat` does not error if the columns do not match. It results in nan values:

```python
import pandas as pd

df1 = pd.DataFrame(data={"col1": [10, 2], "col2": [10, 4]})
df2 = pd.DataFrame(data={"col3": [5, 10], "col4": [5, 10]})

print(pd.concat([df1, df2]).to_markdown())
```

|    |   col1 |   col2 |   col3 |   col4 |
|---:|-------:|-------:|-------:|-------:|
|  0 |     10 |     10 |    nan |    nan |
|  1 |      2 |      4 |    nan |    nan |
|  0 |    nan |    nan |      5 |      5 |
|  1 |    nan |    nan |     10 |     10 |