### PR TITLE
Move dataclass import to code block

### DIFF
--- a/examples/data_types_and_io/data_types_and_io/pytorch_types.py
+++ b/examples/data_types_and_io/data_types_and_io/pytorch_types.py
@@ -73,7 +73,6 @@ def pytorch_native_wf():
 # %% [markdown]
 # Passing around tensors and modules is no more a hassle!
 
-from dataclasses import dataclass
 
 # %% [markdown]
 # ## Checkpoint
@@ -85,6 +84,8 @@ from dataclasses import dataclass
 # As per PyTorch [docs](https://pytorch.org/tutorials/beginner/saving_loading_models.html#save-load-entire-model), it is recommended to
 # store the module's `state_dict` rather than the module itself. However, the serialization should work either way.
 # %%
+from dataclasses import dataclass
+
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim


### PR DESCRIPTION
This PR moves the import to the code block. Currently it is rendered strangely:

![Screenshot 2023-10-31 at 5 51 07 PM](https://github.com/flyteorg/flytesnacks/assets/5402633/63ce9548-21da-4e91-8578-a22714e5d741)
