### PR TITLE
Updates Docker image to fix MNIST example

### DIFF
--- a/examples/mnist_classifier/Dockerfile
+++ b/examples/mnist_classifier/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.9.0-cuda10.2-cudnn7-runtime
+FROM pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime
 LABEL org.opencontainers.image.source https://github.com/flyteorg/flytesnacks
 
 WORKDIR /root


### PR DESCRIPTION
This PR fixes the `mnist_classifier` example by updating the Docker image to `pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime`, which uses Python 3.8. [The CI was failing](https://github.com/flyteorg/flytesnacks/actions/runs/6719790805/job/18262466558) because the `google-cli` requires Python 3.8 or newer:

```
2023-11-01T13:10:19.5531225Z 5.357 Welcome to the Google Cloud CLI!
2023-11-01T13:10:19.5532121Z 5.408 WARNING: You appear to be running this script as root. This may cause 
2023-11-01T13:10:19.5533282Z 5.408 the installation to be inaccessible to users other than the root user.
2023-11-01T13:10:19.5534337Z 6.884 WARNING:  Python 3.7.x is no longer officially supported by the Google Cloud CLI
2023-11-01T13:10:19.5535663Z 6.884 and may not function correctly. Please use Python version 3.8 and up.
```