### PR TITLE
Add missing imports to map_task example

### DIFF
--- a/docs/getting_started/optimizing_tasks.md
+++ b/docs/getting_started/optimizing_tasks.md
@@ -110,9 +110,9 @@ scale our workload:
 
 ```{code-cell} ipython3
 import math
-from typing import Tuple
+from typing import Tuple, List
 
-from flytekit import map_task
+from flytekit import map_task, task, workflow
 
 
 @task


### PR DESCRIPTION
Unless I'm missing something very obvious, there's no way this example could run without the missing imports.