### PR TITLE
Rename monodocs build in CI

### DIFF
--- a/.github/workflows/monodocs_build.yml
+++ b/.github/workflows/monodocs_build.yml
@@ -1,4 +1,4 @@
-name: Docs Build
+name: Monodocs Build
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
I think this GitHub workflow runs into the same issue from https://github.com/flyteorg/flytekit/pull/2035/files#r1422709924