### PR TITLE
Update Hadoop AWS and AWS SDK jar versions to support com.amazonaws.auth.WebIdentityTokenCredentialsProvider 

### DIFF
--- a/examples/k8s_spark_plugin/Dockerfile
+++ b/examples/k8s_spark_plugin/Dockerfile
@@ -26,8 +26,8 @@ RUN pip3 install wheel
 COPY requirements.txt /root
 RUN pip install -r /root/requirements.txt
 
-RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.2/hadoop-aws-3.2.2.jar -P /opt/spark/jars && \
-    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P /opt/spark/jars
+RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.6/hadoop-aws-3.3.6.jar -P /opt/spark/jars && \
+    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.367/aws-java-sdk-bundle-1.12.367.jar -P /opt/spark/jars
 
 # Copy the actual code
 COPY . /root/

--- a/examples/k8s_spark_plugin/Dockerfile
+++ b/examples/k8s_spark_plugin/Dockerfile
@@ -26,8 +26,8 @@ RUN pip3 install wheel
 COPY requirements.txt /root
 RUN pip install -r /root/requirements.txt
 
-RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.6/hadoop-aws-3.3.6.jar -P /opt/spark/jars && \
-    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.367/aws-java-sdk-bundle-1.12.367.jar -P /opt/spark/jars
+RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.4/hadoop-aws-3.2.4.jar -P /opt/spark/jars && \
+    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.901/aws-java-sdk-bundle-1.11.901.jar -P /opt/spark/jars
 
 # Copy the actual code
 COPY . /root/


### PR DESCRIPTION
The previous versions of the hadoop aws and aws sdk java jars do not support com.amazonaws.auth.WebIdentityTokenCredentialsProvider which is what I need to invoke through com.amazonaws.auth.DefaultAWSCredentialsProviderChain.
I found the correct combinations of the versions of jars that works by try and error. 
Note: the latest hadoop aws jar and its dependent aws java sdk bundle jars don’t work for me.