### PR TITLE
Correct order of images in deck example

### DIFF
--- a/examples/development_lifecycle/development_lifecycle/decks.py
+++ b/examples/development_lifecycle/development_lifecycle/decks.py
@@ -237,8 +237,8 @@ def table_renderer() -> None:
 
 
 # %% [markdown]
-# :::{figure} https://raw.githubusercontent.com/flyteorg/static-resources/main/flytesnacks/user_guide/flyte_decks_source_code_renderer.png
-# :alt: Source code renderer
+# :::{figure} https://raw.githubusercontent.com/flyteorg/static-resources/main/flytesnacks/user_guide/flyte_decks_table_renderer.png
+# :alt: Table renderer
 # :class: with-shadow
 # :::
 # #### Source Code Renderer
@@ -261,8 +261,8 @@ def source_code_renderer() -> None:
 
 
 # %% [markdown]
-# :::{figure} https://raw.githubusercontent.com/flyteorg/static-resources/main/flytesnacks/user_guide/flyte_decks_table_renderer.png
-# :alt: Table renderer
+# :::{figure} https://raw.githubusercontent.com/flyteorg/static-resources/main/flytesnacks/user_guide/flyte_decks_source_code_renderer.png
+# :alt: Source code renderer
 # :class: with-shadow
 # :::
 #


### PR DESCRIPTION
On the [deck docs](https://docs.flyte.org/projects/cookbook/en/latest/auto_examples/development_lifecycle/decks.html#table-renderer) the "Source Code Renderer" image is flipped with the "Table Renderer" image.