### PR TITLE
Add link to hosted sandbox to Quickstart guide

### DIFF
--- a/docs/getting_started/quickstart_guide.md
+++ b/docs/getting_started/quickstart_guide.md
@@ -17,6 +17,12 @@ next-page-title: Getting started with workflow development
 
 In this guide, you will create and run a Flyte workflow in a local Python environment to generate the output "Hello, world!"
 
+```{note}
+
+To try Flyte in a hosted environment, see the [Union Cloud sandbox](https://sandbox.union.ai/).
+
+```
+
 ## Prerequisites
 
 * [Install Python 3.8x or higher](https://www.python.org/downloads/)


### PR DESCRIPTION
In splitting the old quickstart guide into two pages (landing page of "Getting started with workflow development" and "Quickstart guide", I removed the link to the hosted sandbox. This PR adds the link back to the Quickstart guide, but I can add it to the landing page or the docs index page if we want readers to find it earlier.