### PR TITLE
Clarify that only pandas is needed for StructuredDataset

### DIFF
--- a/examples/data_types_and_io/data_types_and_io/structured_dataset.py
+++ b/examples/data_types_and_io/data_types_and_io/structured_dataset.py
@@ -21,9 +21,20 @@
 #   (not only at compile time, but also runtime since type information is carried along in the literal),
 #    store third-party schema definitions, and potentially in the future, render sample data, provide summary statistics, etc.
 #
-# This example demonstrates how to work with a structured dataset using Flyte entities.
+# ## Usage
 #
-# To begin, import the necessary dependencies.
+# To use the `StructuredDataset` type, import `pandas` and define a task that returns a Pandas Dataframe.
+# Flytekit will detect the Pandas DataFrame return signature and convert the interface for the task to
+# the {py:class}`StructuredDataset` type.
+#
+# ## Example
+# This example demonstrates how to work with a structured dataset using Flyte entities.
+# ```{note}
+# To use the `StructuredDataset` type, you only need to import `pandas`.
+# The other imports specified below are only necessary for this specific example.
+# ```
+#
+# To begin, import the dependencies for the example.
 # %%
 import os
 import typing
@@ -47,8 +58,6 @@ from typing_extensions import Annotated
 
 # %% [markdown]
 # Define a task that returns a Pandas DataFrame.
-# Flytekit will detect the Pandas dataframe return signature and
-# convert the interface for the task to the new {py:class}`StructuredDataset` type.
 # %%
 @task
 def generate_pandas_df(a: int) -> pd.DataFrame:

--- a/examples/mnist_classifier/mnist_classifier/pytorch_single_node_multi_gpu.py
+++ b/examples/mnist_classifier/mnist_classifier/pytorch_single_node_multi_gpu.py
@@ -370,11 +370,11 @@ if os.getenv("SANDBOX") != "":
     mem = "100Mi"
     gpu = "0"
     storage = "500Mi"
-    ephemeral_storage = "500Mi"
+    ephemeral_storage = "20Mi"
 else:
     mem = "30Gi"
     gpu = str(WORLD_SIZE)
-    ephemeral_storage = "20Mi"
+    ephemeral_storage = "500Mi"
     storage = "20Gi"
 
 

--- a/examples/mnist_classifier/mnist_classifier/pytorch_single_node_multi_gpu.py
+++ b/examples/mnist_classifier/mnist_classifier/pytorch_single_node_multi_gpu.py
@@ -374,7 +374,7 @@ if os.getenv("SANDBOX") != "":
 else:
     mem = "30Gi"
     gpu = str(WORLD_SIZE)
-    ephemeral_storage = "500Mi"
+    ephemeral_storage = "20Mi"
     storage = "20Gi"
 
 

--- a/examples/mnist_classifier/mnist_classifier/pytorch_single_node_multi_gpu.py
+++ b/examples/mnist_classifier/mnist_classifier/pytorch_single_node_multi_gpu.py
@@ -370,7 +370,7 @@ if os.getenv("SANDBOX") != "":
     mem = "100Mi"
     gpu = "0"
     storage = "500Mi"
-    ephemeral_storage = "500Mi"
+    ephemeral_storage = "20Mi"
 else:
     mem = "30Gi"
     gpu = str(WORLD_SIZE)

--- a/examples/mnist_classifier/mnist_classifier/pytorch_single_node_multi_gpu.py
+++ b/examples/mnist_classifier/mnist_classifier/pytorch_single_node_multi_gpu.py
@@ -370,7 +370,7 @@ if os.getenv("SANDBOX") != "":
     mem = "100Mi"
     gpu = "0"
     storage = "500Mi"
-    ephemeral_storage = "20Mi"
+    ephemeral_storage = "500Mi"
 else:
     mem = "30Gi"
     gpu = str(WORLD_SIZE)


### PR DESCRIPTION
The current [StructuredDataset doc](https://docs.flyte.org/en/latest/flytesnacks/examples/data_types_and_io/structured_dataset.html) implies that you need to import a slew of dependencies to use the StructuredDataset type, which is not true. In this PR: light edits to that doc to make it clear users only need to import pandas to use the StructuredDataset type.