### PR TITLE
Agents docs - link to doc instead of ref

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -90,17 +90,17 @@ orchestrated by Flyte itself, within its provisioned Kubernetes clusters.
 :header-rows: 0
 :widths: 20 30
 
-* - {ref}`Airflow agent <airflow_agent>`
+* - {doc}`Airflow agent <auto_examples/airflow_agent/index>`
   - Run Airflow jobs in your workflows with the Airflow agent.
-* - {ref}`BigQuery agent <bigquery_agent>`
+* - {doc}`BigQuery agent <auto_examples/bigquery_integration/bigquery_agent>`
   - Run BigQuery jobs in your workflows with the BigQuery agent.
-* - {ref}`Databricks <databricks_agent>`
+* - {doc}`Databricks <auto_examples/databricks_integration/databricks_agent>`
   - Run Databricks jobs in your workflows with the Databricks agent.
-* - {ref}`Memory Machine Cloud <mmcloud_agent>`
+* - {doc}`Memory Machine Cloud <auto_examples/mmcloud_integration/mmcloud_agent>`
   - Execute tasks using the MemVerge Memory Machine Cloud agent.
 * - {doc}`Sensor <auto_examples/sensor/index>`
   - Run sensor jobs in your workflows with the sensor agent.
-* - {ref}`Snowflake <snowflake_agent>`
+* - {doc}`Snowflake <auto_examples/snowflake_integration/snowflake_agent>`
   - Run Snowflake jobs in your workflows with the Snowflake agent.
 ```
 
@@ -130,13 +130,13 @@ the Flyte task that use the respective plugin.
   - Execute tasks using Flyte Interactive to debug.
 * - {doc}`Hive plugin <auto_examples/hive_plugin/index>`
   - Run Hive jobs in your workflows.
-* - {ref}`MMCloud plugin <mmcloud_plugin>`
+* - {doc}`MMCloud plugin <auto_examples/mmcloud_integration/mmcloud_plugin>`
   - Execute tasks using MemVerge Memory Machine Cloud
-* - {ref}`Snowflake <snowflake_plugin>`
+* - {doc}`Snowflake <auto_examples/snowflake_integration/snowflake_plugin>`
   - Run Snowflake jobs in your workflows.
-* - {ref}`Databricks <databricks_plugin>`
+* - {doc}`Databricks <auto_examples/databricks_integration/databricks_plugin>`
   - Run Databricks jobs in your workflows.
-* - {ref}`BigQuery <bigquery_plugin>`
+* - {doc}`BigQuery <auto_examples/bigquery_integration/bigquery_plugin>`
   - Run BigQuery jobs in your workflows.
 ```
 


### PR DESCRIPTION
The master build is breaking with [this warning](https://github.com/flyteorg/flytesnacks/actions/runs/8023039610/job/21918671861#step:7:93009): `/home/runner/work/flytesnacks/flytesnacks/flyte/docs/flytesnacks/integrations.md:10091:toctree contains reference to nonexisting document 'flytesnacks/airflow_agent'`

I think in order to get the monodocs build working, I need to link to docs instead of refs on the integrations landing page.