### PR TITLE
Update docs links

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -192,7 +192,7 @@ If the example code can be run locally, just use `python <my_file>.py` to run it
 Install {doc}`flytectl <flytectl:index>`, the commandline interface for flyte.
 
 :::{note}
-Learn more about installation and configuration of Flytectl [here](https://docs.flyte.org/projects/flytectl/en/latest/index.html).
+Learn more about installation and configuration of Flytectl [here](https://docs.flyte.org/en/latest/flytectl/docs_index.html).
 :::
 
 Start a Flyte demo cluster with:

--- a/examples/airflow_plugin/airflow_plugin/airflow.py
+++ b/examples/airflow_plugin/airflow_plugin/airflow.py
@@ -52,7 +52,7 @@
 #
 # **FLYTE**
 #
-# The [getting started tutorial](https://docs.flyte.org/en/latest/getting_started/index.html) should help you with setting up Flyte.
+# The [Quickstart guide](https://docs.flyte.org/en/latest/quickstart_guide.html) should help you with setting up Flyte.
 #
 # ## Create an Airflow Connection
 #
@@ -72,7 +72,7 @@
 # ## Register Flyte Code
 #
 # At the Flyte end, we'll train an XGBoost model on Pima Indians Diabetes Dataset.
-# The source code is available [here](https://github.com/flyteorg/flytesnacks/blob/master/cookbook/case_studies/pima_diabetes/diabetes.py).
+# The source code is available [here](https://github.com/flyteorg/flytesnacks/blob/master/examples/pima_diabetes/pima_diabetes/diabetes.py ).
 #
 # Register the example on the Flyte backend before proceeding with running the Airflow DAG.
 #

--- a/examples/exploratory_data_analysis/exploratory_data_analysis/notebook.py
+++ b/examples/exploratory_data_analysis/exploratory_data_analysis/notebook.py
@@ -14,7 +14,7 @@ from flytekit import Resources, kwtypes, workflow
 from flytekitplugins.papermill import NotebookTask
 
 # %% [markdown]
-# We define a `NotebookTask` to run the [Jupyter notebook](https://github.com/flyteorg/flytesnacks/blob/master/cookbook/case_studies/feature_engineering/eda/supermarket_regression.ipynb).
+# We define a `NotebookTask` to run the [Jupyter notebook](https://github.com/flyteorg/flytesnacks/blob/master/examples/exploratory_data_analysis/exploratory_data_analysis/supermarket_regression.ipynb).
 #
 # ```{eval-rst}
 # .. list-table:: ``NotebookTask`` Parameters

--- a/examples/exploratory_data_analysis/exploratory_data_analysis/notebook_and_task.py
+++ b/examples/exploratory_data_analysis/exploratory_data_analysis/notebook_and_task.py
@@ -37,7 +37,7 @@ class Hyperparameters(object):
 
 
 # %% [markdown]
-# We define a `NotebookTask` to run the [Jupyter notebook](https://github.com/flyteorg/flytesnacks/blob/master/cookbook/case_studies/feature_engineering/eda/supermarket_regression_1.ipynb).
+# We define a `NotebookTask` to run the [Jupyter notebook](https://github.com/flyteorg/flytesnacks/blob/master/examples/exploratory_data_analysis/exploratory_data_analysis/supermarket_regression_1.ipynb).
 # This notebook returns `dummified_data` and `dataset` as the outputs.
 #
 # :::{note}

--- a/examples/exploratory_data_analysis/exploratory_data_analysis/notebooks_as_tasks.py
+++ b/examples/exploratory_data_analysis/exploratory_data_analysis/notebooks_as_tasks.py
@@ -16,7 +16,7 @@ from flytekit import Resources, kwtypes, workflow
 from flytekitplugins.papermill import NotebookTask
 
 # %% [markdown]
-# We define a `NotebookTask` to run the [Jupyter notebook](https://github.com/flyteorg/flytesnacks/blob/master/cookbook/case_studies/feature_engineering/eda/supermarket_regression_1.ipynb) (EDA).
+# We define a `NotebookTask` to run the [Jupyter notebook](https://github.com/flyteorg/flytesnacks/blob/master/examples/exploratory_data_analysis/exploratory_data_analysis/supermarket_regression_1.ipynb) (EDA).
 # This notebook returns `dummified_data` and `dataset` as the outputs.
 #
 # :::{note}
@@ -33,7 +33,7 @@ nb_1 = NotebookTask(
 )
 
 # %% [markdown]
-# We define a `NotebookTask` to run the [Jupyter notebook](https://github.com/flyteorg/flytesnacks/blob/master/cookbook/case_studies/feature_engineering/eda/supermarket_regression_2.ipynb)
+# We define a `NotebookTask` to run the [Jupyter notebook](https://github.com/flyteorg/flytesnacks/blob/master/examples/exploratory_data_analysis/exploratory_data_analysis/supermarket_regression_2.ipynb)
 # (Modeling).
 #
 # This notebook returns `mae_score` as the output.

--- a/examples/kfmpi_plugin/kfmpi_plugin/mpi_mnist.py
+++ b/examples/kfmpi_plugin/kfmpi_plugin/mpi_mnist.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 # In the context of distributed training, it's important to acknowledge that return values from various workers could potentially vary.
 # If you need to regulate which worker's return value gets passed on to subsequent tasks in the workflow,
 # you have the option to raise an
-# [IgnoreOutputs exception](https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.core.base_task.IgnoreOutputs.html)
+# [IgnoreOutputs exception](https://docs.flyte.org/en/latest/api/flytekit/generated/flytekit.core.base_task.IgnoreOutputs.html#flytekit-core-base-task-ignoreoutputs)
 # for all remaining ranks.
 # :::
 # %%

--- a/examples/kftensorflow_plugin/kftensorflow_plugin/tf_mnist.py
+++ b/examples/kftensorflow_plugin/kftensorflow_plugin/tf_mnist.py
@@ -244,6 +244,6 @@ if __name__ == "__main__":
 # In the context of distributed training, it's important to acknowledge that return values from various workers could potentially vary.
 # If you need to regulate which worker's return value gets passed on to subsequent tasks in the workflow,
 # you have the option to raise an
-# [IgnoreOutputs exception](https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.core.base_task.IgnoreOutputs.html)
+# [IgnoreOutputs exception](https://docs.flyte.org/en/latest/api/flytekit/generated/flytekit.core.base_task.IgnoreOutputs.html#flytekit-core-base-task-ignoreoutputs)
 # for all remaining ranks.
 # :::

--- a/examples/mmcloud_plugin/README.md
+++ b/examples/mmcloud_plugin/README.md
@@ -43,13 +43,13 @@ This plugin allows executing `PythonFunctionTask` using MMCloud without changing
         return str(i)
 ```
 
-[Resource](https://docs.flyte.org/en/latest/flytesnacks/examples/productionizing/customizing_resources.html) (cpu and mem) requests and limits, [container](https://docs.flyte.org/en/latest/flytesnacks/examples/customizing_dependencies/multi_images.html) images, and environment variable specifications are supported.
+[Resource](https://docs.flyte.org/en/latest/user_guide/productionizing/customizing_task_resources.html) (cpu and mem) requests and limits, [container](https://docs.flyte.org/en/latest/user_guide/customizing_dependencies/multiple_images_in_a_workflow.html) images, and environment variable specifications are supported.
 
-[ImageSpec](https://docs.flyte.org/en/latest/flytesnacks/examples/customizing_dependencies/image_spec.html#image-spec-example) may be used to define images to run tasks.
+[ImageSpec](https://docs.flyte.org/en/latest/user_guide/customizing_dependencies/imagespec.html#image-spec-example) may be used to define images to run tasks.
 
 ### Credentials
 
-The following [secrets](https://docs.flyte.org/en/latest/flytesnacks/examples/productionizing/use_secrets.html) are required to be defined for the agent server:
+The following [secrets](https://docs.flyte.org/en/latest/user_guide/productionizing/secrets.html) are required to be defined for the agent server:
 * `mmc_address`: MMCloud OpCenter address
 * `mmc_username`: MMCloud OpCenter username
 * `mmc_password`: MMCloud OpCenter password

--- a/examples/mmcloud_plugin/mmcloud_plugin/mmcloud_plugin_example.py
+++ b/examples/mmcloud_plugin/mmcloud_plugin/mmcloud_plugin_example.py
@@ -23,7 +23,7 @@ def to_int(s: str) -> int:
 
 
 # %% [markdown]
-# [Resource](https://docs.flyte.org/projects/cookbook/en/latest/auto_examples/productionizing/customizing_resources.html) (cpu and mem) requests and limits, [container](https://docs.flyte.org/projects/cookbook/en/latest/auto_examples/customizing_dependencies/multi_images.html) images, and [environment](https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.task.html) variable specifications are supported.
+# [Resource](https://docs.flyte.org/en/latest/user_guide/productionizing/customizing_task_resources.html) (cpu and mem) requests and limits, [container](https://docs.flyte.org/en/latest/user_guide/customizing_dependencies/multiple_images_in_a_workflow.html) images, and [environment](https://docs.flyte.org/en/latest/api/flytekit/generated/flytekit.task.html) variable specifications are supported.
 
 # %%
 @task(


### PR DESCRIPTION
Updates docs links so they don't break when we fully switch to new monodocs build.

Also updates links directly to the flytesnacks repo, since those are currently broken.