### PR TITLE
Change `flytekitplugins.chatgpt` to `flytekitplugins.openai` in ChatGPT Example

### DIFF
--- a/examples/chatgpt_agent/README.md
+++ b/examples/chatgpt_agent/README.md
@@ -9,7 +9,7 @@ To install the ChatGPT agent, run the following command:
 ```{eval-rst}
 .. prompt:: bash
 
-    pip install flytekitplugins-chatgpt
+    pip install flytekitplugins-openai
 ```
 
 ## Example usage

--- a/examples/chatgpt_agent/chatgpt_agent/chatgpt_agent_example_usage.py
+++ b/examples/chatgpt_agent/chatgpt_agent/chatgpt_agent_example_usage.py
@@ -66,13 +66,11 @@ if __name__ == "__main__":
 # ### Summarize Flyte's latest GitHub releases to Slack
 #
 # %%
-flytekit_master = "git+https://github.com/flyteorg/flytekit.git@master"
-chatgpt_plugin = "git+https://github.com/flyteorg/flytekit.git@master#subdirectory=plugins/flytekit-openai"
+
 image = ImageSpec(
     apt_packages=["git"],
     packages=[
-        flytekit_master,
-        chatgpt_plugin,
+        "flytekitplugins-chatgpt",
         "requests",
         "slack_sdk",
     ],
@@ -146,13 +144,10 @@ if __name__ == "__main__":
 # %% [markdown]
 # ### Summarize Flyte's latest YouTube Video to Slack
 # %%
-flytekit_master = "git+https://github.com/flyteorg/flytekit.git@master"
-chatgpt_plugin = "git+https://github.com/flyteorg/flytekit.git@master#subdirectory=plugins/flytekit-openai"
 image = ImageSpec(
     apt_packages=["git"],
     packages=[
-        flytekit_master,
-        chatgpt_plugin,
+        "flytekitplugins-chatgpt",
         "scrapetube==2.5.1",
         "youtube_transcript_api==0.6.1",
         "slack_sdk==3.23.0",

--- a/examples/chatgpt_agent/chatgpt_agent/chatgpt_agent_example_usage.py
+++ b/examples/chatgpt_agent/chatgpt_agent/chatgpt_agent_example_usage.py
@@ -12,7 +12,7 @@ from typing import List
 
 import flytekit
 from flytekit import ImageSpec, Secret, dynamic, task, workflow
-from flytekitplugins.chatgpt import ChatGPTTask
+from flytekitplugins.openai import ChatGPTTask
 
 # %% [markdown]
 # You have to specify your `name`, `openai_organization` and `chatgpt_config`.

--- a/examples/chatgpt_agent/chatgpt_agent/chatgpt_agent_example_usage.py
+++ b/examples/chatgpt_agent/chatgpt_agent/chatgpt_agent_example_usage.py
@@ -66,7 +66,6 @@ if __name__ == "__main__":
 # ### Summarize Flyte's latest GitHub releases to Slack
 #
 # %%
-
 image = ImageSpec(
     apt_packages=["git"],
     packages=[


### PR DESCRIPTION
As title.

example: https://flyte--1548.org.readthedocs.build/projects/cookbook/en/1548/auto_examples/chatgpt_agent/chatgpt_agent_example_usage.html