### PR TITLE
Update flyte_tests_manifest.json

### DIFF
--- a/flyte_tests_manifest.json
+++ b/flyte_tests_manifest.json
@@ -88,8 +88,7 @@
     "path": "examples/k8s_spark_plugin",
     "examples": [
       [
-        "k8s_spark_plugin.pyspark_pi.my_spark",
-        { "triggered_date": "2023-11-21T18:58:01" }
+        "k8s_spark_plugin.pyspark_pi.my_spark", {},
       ]
     ],
     "exitCondition": {

--- a/flyte_tests_manifest.json
+++ b/flyte_tests_manifest.json
@@ -88,7 +88,7 @@
     "path": "examples/k8s_spark_plugin",
     "examples": [
       [
-        "k8s_spark_plugin.pyspark_pi.my_spark", {},
+        "k8s_spark_plugin.pyspark_pi.my_spark", {}
       ]
     ],
     "exitCondition": {


### PR DESCRIPTION
https://github.com/flyteorg/boilerplate/pull/94/ removed the definition of the tests from `run-tests.py` in favor of representing the tests and their inputs in josn. However `k8s_spark_plugin.pyspark_pi.my_spark` expects `triggered_date` to be a datetime. 

Since this can't be represented in json (and we don't want to change the parameter type),  let's rely on the default value defined in the workflow. 