### PR TITLE
docs(ray): Update ray version compatibility in warning and add wget to ImageSpec

### DIFF
--- a/examples/ray_plugin/ray_plugin/ray_example.py
+++ b/examples/ray_plugin/ray_plugin/ray_example.py
@@ -5,19 +5,9 @@
 # or by creating a new Ray cluster using the Ray operator.
 #
 # :::{Warning}
-# **Known Bugs and Compatibility Issue with Kuberay Operator Versions**
-# Please note that there have been reports of various bugs and compatibility issues with recent versions of the Kuberay operator.
-# - Kuberay Operator Version 0.4: In this version, the reconcile logic of the operator was changed.
-#   As a result, when running a Ray job, the status of the job will always remain "pending."
-#   It is important to note that this change was not thoroughly tested by the Kuberay community before its release.
-# - Kuberay Operator Version 0.5: In this version, an init container is injected into the worker nodes.
-#   However, the operator failed to set the required resource limits (CPU, memory) for this init container.
-#   Consequently, running Ray jobs becomes problematic in Flyte because Kubernetes imposes resource quotas in every project-domain namespace,
-#   and these quotas necessitate that every container sets the CPU and memory limits.
-#
-# **Given these issues, it is crucial to be aware that the current Ray extension is compatible only
-# with version 0.3.0 and 0.5.2+ of the Kuberay operator.** It is recommended to use this specific version to
-# ensure the proper functioning of the Ray extension.
+# **Version Compatibility**
+# - flyte >= 1.11.1-b1 only works with kuberay 1.1.0
+# - Although flyte < 1.11.0 can work with kuberay 0.6.0 and 1.1.0, we strongly recommend upgrading to the latest flyte and kuberay 1.1.0 for stability and usability
 # :::
 #
 # To begin, load the libraries.
@@ -32,6 +22,8 @@ from flytekit import ImageSpec, Resources, task, workflow
 custom_image = ImageSpec(
     registry="ghcr.io/flyteorg",
     packages=["flytekitplugins-ray"],
+    # kuberay operator needs wget for readiness probe
+    apt_packages=["wget"],
 )
 
 # %% [markdown]


### PR DESCRIPTION
The newest flyte and ray have different compatibility requirements, so we need to update the documentation.
Futhermore, the newest ray operator needs `wget` for readiness probing purpose, so add `wget` to `ImageSpec`