### PR TITLE
[WAIT TO MERGE] Update link to local agent testing doc

### DIFF
--- a/examples/bigquery_agent/README.md
+++ b/examples/bigquery_agent/README.md
@@ -20,7 +20,7 @@ For an example query, see {doc}`BigQuery agent example usage<bigquery_agent_exam
 
 ## Local testing
 
-To test the BigQuery agent locally, create a class for the agent task that inherits from [AsyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L262). This mixin can handle asynchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_locally.html)".
+To test the BigQuery agent locally, create a class for the agent task that inherits from [AsyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L262). This mixin can handle asynchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_in_a_local_python_environment.html)".
 
 ```{note}
 

--- a/examples/chatgpt_agent/README.md
+++ b/examples/chatgpt_agent/README.md
@@ -18,7 +18,7 @@ For an example job, see {doc}`ChatGPT agent example usage<chatgpt_agent_example_
 
 ## Local testing
 
-To test the ChatGPT agent locally, create a class for the agent task that inherits from [SyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L225). This mixin can handle synchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_locally.html)".
+To test the ChatGPT agent locally, create a class for the agent task that inherits from [SyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L225). This mixin can handle synchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_in_a_local_python_environment.html)".
 
 ```{note}
 

--- a/examples/databricks_agent/README.md
+++ b/examples/databricks_agent/README.md
@@ -24,7 +24,7 @@ For a usage example, see {doc}`Databricks agent example usage<databricks_agent_e
 
 ## Local testing
 
-To test the Databricks agent locally, create a class for the agent task that inherits from [AsyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L262). This mixin can handle asynchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_locally.html)".
+To test the Databricks agent locally, create a class for the agent task that inherits from [AsyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L262). This mixin can handle asynchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_in_a_local_python_environment.html)".
 
 ```{note}
 

--- a/examples/mmcloud_agent/README.md
+++ b/examples/mmcloud_agent/README.md
@@ -26,7 +26,7 @@ For a usage example, see {doc}`Memory Machine Cloud agent example usage<mmcloud_
 
 ## Local testing
 
-To test the MMCloud agent locally, create a class for the agent task that inherits from [AsyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L262). This mixin can handle asynchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_locally.html)".
+To test the MMCloud agent locally, create a class for the agent task that inherits from [AsyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L262). This mixin can handle asynchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_in_a_local_python_environment.html)".
 
 ```{note}
 

--- a/examples/snowflake_agent/README.md
+++ b/examples/snowflake_agent/README.md
@@ -22,7 +22,7 @@ For a usage example, see {doc}`Snowflake agent example usage<snowflake_agent_exa
 
 ## Local testing
 
-To test the Snowflake agent locally, create a class for the agent task that inherits from [AsyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L262). This mixin can handle asynchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_locally.html)".
+To test the Snowflake agent locally, create a class for the agent task that inherits from [AsyncAgentExecutorMixin](https://github.com/flyteorg/flytekit/blob/master/flytekit/extend/backend/base_agent.py#L262). This mixin can handle asynchronous tasks and allows flytekit to mimic FlytePropeller's behavior in calling the agent. For more information, see "[Testing agents locally](https://docs.flyte.org/en/latest/flyte_agents/testing_agents_in_a_local_python_environment.html)".
 
 ```{note}
 


### PR DESCRIPTION
"Testing agents locally" has been renamed to "Testing agents in a local Python environment" in https://github.com/flyteorg/flyte/pull/5106

Wait to merge until https://github.com/flyteorg/flyte/pull/5106 has been merged.
