### PR TITLE
remove `source code renderer`

### DIFF
--- a/examples/development_lifecycle/development_lifecycle/decks.py
+++ b/examples/development_lifecycle/development_lifecycle/decks.py
@@ -121,21 +121,3 @@ def table_renderer() -> None:
         "Table Renderer",
         TableRenderer().to_html(df=pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]}), table_width=50),
     )
-
-
-# #### Source code renderer converts source code to HTML
-# and renders it as a Unicode string on the deck.
-import inspect
-
-from flytekitplugins.deck.renderer import SourceCodeRenderer
-
-
-@task(enable_deck=True)
-def source_code_renderer() -> None:
-    file_path = inspect.getsourcefile(frame_renderer.__wrapped__)
-    with open(file_path, "r") as f:
-        source_code = f.read()
-    flytekit.Deck(
-        "Source Code Renderer",
-        SourceCodeRenderer().to_html(source_code),
-    )


### PR DESCRIPTION
- Remove `source code renderer` because it has been merged into default