### PR TITLE
Import tabulate in each task

### DIFF
--- a/examples/data_types_and_io/data_types_and_io/structured_dataset.py
+++ b/examples/data_types_and_io/data_types_and_io/structured_dataset.py
@@ -16,7 +16,6 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetEncoder,
     StructuredDatasetTransformerEngine,
 )
-from tabulate import tabulate
 from typing_extensions import Annotated
 
 
@@ -203,6 +202,7 @@ image = ImageSpec(packages=["pandas", "tabulate"], registry="ghcr.io/flyteorg")
 
 @task(container_image=image)
 def create_parquet_file() -> StructuredDataset:
+    from tabulate import tabulate
     df = pd.json_normalize(data, max_level=0)
     print("original dataframe: \n", tabulate(df, headers="keys", tablefmt="psql"))
 
@@ -211,6 +211,7 @@ def create_parquet_file() -> StructuredDataset:
 
 @task(container_image=image)
 def print_table_by_arg(sd: MyArgDataset) -> pd.DataFrame:
+    from tabulate import tabulate
     t = sd.open(pd.DataFrame).all()
     print("MyArgDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -218,6 +219,7 @@ def print_table_by_arg(sd: MyArgDataset) -> pd.DataFrame:
 
 @task(container_image=image)
 def print_table_by_dict(sd: MyDictDataset) -> pd.DataFrame:
+    from tabulate import tabulate
     t = sd.open(pd.DataFrame).all()
     print("MyDictDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -225,6 +227,7 @@ def print_table_by_dict(sd: MyDictDataset) -> pd.DataFrame:
 
 @task(container_image=image)
 def print_table_by_list_dict(sd: MyDictListDataset) -> pd.DataFrame:
+    from tabulate import tabulate
     t = sd.open(pd.DataFrame).all()
     print("MyDictListDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -232,6 +235,7 @@ def print_table_by_list_dict(sd: MyDictListDataset) -> pd.DataFrame:
 
 @task(container_image=image)
 def print_table_by_top_dataclass(sd: MyTopDataClassDataset) -> pd.DataFrame:
+    from tabulate import tabulate
     t = sd.open(pd.DataFrame).all()
     print("MyTopDataClassDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -239,6 +243,7 @@ def print_table_by_top_dataclass(sd: MyTopDataClassDataset) -> pd.DataFrame:
 
 @task(container_image=image)
 def print_table_by_top_dict(sd: MyTopDictDataset) -> pd.DataFrame:
+    from tabulate import tabulate
     t = sd.open(pd.DataFrame).all()
     print("MyTopDictDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -246,6 +251,7 @@ def print_table_by_top_dict(sd: MyTopDictDataset) -> pd.DataFrame:
 
 @task(container_image=image)
 def print_table_by_second_dataclass(sd: MySecondDataClassDataset) -> pd.DataFrame:
+    from tabulate import tabulate
     t = sd.open(pd.DataFrame).all()
     print("MySecondDataClassDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -253,6 +259,7 @@ def print_table_by_second_dataclass(sd: MySecondDataClassDataset) -> pd.DataFram
 
 @task(container_image=image)
 def print_table_by_nested_dataclass(sd: MyNestedDataClassDataset) -> pd.DataFrame:
+    from tabulate import tabulate
     t = sd.open(pd.DataFrame).all()
     print("MyNestedDataClassDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t

--- a/examples/data_types_and_io/data_types_and_io/structured_dataset.py
+++ b/examples/data_types_and_io/data_types_and_io/structured_dataset.py
@@ -203,6 +203,7 @@ image = ImageSpec(packages=["pandas", "tabulate"], registry="ghcr.io/flyteorg")
 @task(container_image=image)
 def create_parquet_file() -> StructuredDataset:
     from tabulate import tabulate
+
     df = pd.json_normalize(data, max_level=0)
     print("original dataframe: \n", tabulate(df, headers="keys", tablefmt="psql"))
 
@@ -212,6 +213,7 @@ def create_parquet_file() -> StructuredDataset:
 @task(container_image=image)
 def print_table_by_arg(sd: MyArgDataset) -> pd.DataFrame:
     from tabulate import tabulate
+
     t = sd.open(pd.DataFrame).all()
     print("MyArgDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -220,6 +222,7 @@ def print_table_by_arg(sd: MyArgDataset) -> pd.DataFrame:
 @task(container_image=image)
 def print_table_by_dict(sd: MyDictDataset) -> pd.DataFrame:
     from tabulate import tabulate
+
     t = sd.open(pd.DataFrame).all()
     print("MyDictDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -228,6 +231,7 @@ def print_table_by_dict(sd: MyDictDataset) -> pd.DataFrame:
 @task(container_image=image)
 def print_table_by_list_dict(sd: MyDictListDataset) -> pd.DataFrame:
     from tabulate import tabulate
+
     t = sd.open(pd.DataFrame).all()
     print("MyDictListDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -236,6 +240,7 @@ def print_table_by_list_dict(sd: MyDictListDataset) -> pd.DataFrame:
 @task(container_image=image)
 def print_table_by_top_dataclass(sd: MyTopDataClassDataset) -> pd.DataFrame:
     from tabulate import tabulate
+
     t = sd.open(pd.DataFrame).all()
     print("MyTopDataClassDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -244,6 +249,7 @@ def print_table_by_top_dataclass(sd: MyTopDataClassDataset) -> pd.DataFrame:
 @task(container_image=image)
 def print_table_by_top_dict(sd: MyTopDictDataset) -> pd.DataFrame:
     from tabulate import tabulate
+
     t = sd.open(pd.DataFrame).all()
     print("MyTopDictDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -252,6 +258,7 @@ def print_table_by_top_dict(sd: MyTopDictDataset) -> pd.DataFrame:
 @task(container_image=image)
 def print_table_by_second_dataclass(sd: MySecondDataClassDataset) -> pd.DataFrame:
     from tabulate import tabulate
+
     t = sd.open(pd.DataFrame).all()
     print("MySecondDataClassDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t
@@ -260,6 +267,7 @@ def print_table_by_second_dataclass(sd: MySecondDataClassDataset) -> pd.DataFram
 @task(container_image=image)
 def print_table_by_nested_dataclass(sd: MyNestedDataClassDataset) -> pd.DataFrame:
     from tabulate import tabulate
+
     t = sd.open(pd.DataFrame).all()
     print("MyNestedDataClassDataset dataframe: \n", tabulate(t, headers="keys", tablefmt="psql"))
     return t


### PR DESCRIPTION
Single binary tests register specific tests, including the structured dataset ones. However it doesn't assume any dependency but flytekit. https://github.com/flyteorg/flytesnacks/pull/1657 is causing errors like https://github.com/flyteorg/flyte/actions/runs/9051152362/job/24867437507.

In this PR we bring the import of the `tabulate` function inside each task that use it.