### PR TITLE
Revert "Pin fsspec<2024.5.0 (#1680)"

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
-      - uses: unionai/flytectl-setup-action@v0.0.1
+      - uses: unionai/flytectl-setup-action@v0.0.3
       - name: setup download artifact dir
         run: |
           mkdir download-artifact
@@ -279,7 +279,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - uses: unionai/flytectl-setup-action@v0.0.1
+      - uses: unionai/flytectl-setup-action@v0.0.3
       - name: Setup sandbox
         run: |
           mkdir -p ~/.flyte/sandbox

--- a/.github/workflows/serialize_example.yml
+++ b/.github/workflows/serialize_example.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
-      - uses: unionai/flytectl-setup-action@v0.0.1
+      - uses: unionai/flytectl-setup-action@v0.0.3
       - name: setup download artifact dir
         run: |
           mkdir download-artifact

--- a/examples/basics/Dockerfile
+++ b/examples/basics/Dockerfile
@@ -17,7 +17,7 @@ ENV VENV /opt/venv
 RUN python3 -m venv ${VENV}
 ENV PATH="${VENV}/bin:$PATH"
 
-RUN pip install flytekit==1.10.0 flytekitplugins-envd "fsspec<2024.5.0"
+RUN pip install flytekit==1.10.0 flytekitplugins-envd
 
 # Copy the actual code
 COPY . /root


### PR DESCRIPTION
This reverts commit ffcfb445f62c9c9bf86955555cb11485eae06c00.

As mentioned in https://github.com/flyteorg/flyte/issues/5375#issuecomment-2113990201, we have a new version of `gcsfs`. 

Tested in https://demo-gcp.hosted.unionai.cloud/console/projects/flytesnacks/domains/development/executions/f3a7fe63580994eae8f2/nodeId/n0/nodes.