### PR TITLE
Catch mutable default argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 120
-select = ["E", "W", "F", "I"]
+select = ["E", "W", "F", "I", "B006"]
 ignore = [
     # Whitespace before '{symbol}'
     "E203",


### PR DESCRIPTION
Fixes https://github.com/flyteorg/flyte/issues/5383

This PR enables https://docs.astral.sh/ruff/rules/mutable-argument-default/ in the ruff rules.