### PR TITLE
Use native protobuf implementation in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -65,7 +65,6 @@ jobs:
     runs-on: "ubuntu-latest"
     env:
       FLYTE_SDK_RICH_TRACEBACKS: "0"
-      PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The new release of brought in the new major version of the protobuf library (protobuf 5), which ended up breaking the compatibility environment variable used to ease the transition to protobuf 4.

