### PR TITLE
update ci

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -163,7 +163,7 @@ jobs:
           flytectl config init
       - name: Register examples
         run: |
-          flytectl register files ./download-artifact/**/**/*.tar.gz --archive -p flytesnacks -d development --version latest
+          flytectl register files ./download-artifact/**/* -p flytesnacks -d development --version latest
 
   bump_version:
     name: Bump Version

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,7 +53,7 @@ jobs:
           # TODO: Register and update the examples below. (onnx_plugin, feast_integration, etc)
           echo "PACKAGES=$(find examples -maxdepth 1 -type d -exec basename '{}' \; \
           | grep -v -e 'testing' -e 'examples' \
-          | grep -v -e 'airflow_plugin' -e 'forecasting_sales' -e 'onnx_plugin' -e 'feast_integration' -e 'modin_plugin' -e 'sagemaker_inference_agent' -e 'mnist_classifier' \
+          | grep -v -e 'airflow_plugin' -e 'forecasting_sales' -e 'onnx_plugin' -e 'feast_integration' -e 'modin_plugin' -e 'sagemaker_inference_agent' -e 'mnist_classifier' -e 'openai_batch_agent' \
           | sort \
           | jq --raw-input . \
           | jq --slurp . \

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -163,7 +163,7 @@ jobs:
           flytectl config init
       - name: Register examples
         run: |
-          flytectl register files ./download-artifact/**/*.tar.gz --archive -p flytesnacks -d development --version latest
+          flytectl register files ./download-artifact/**/**/*.tar.gz --archive -p flytesnacks -d development --version latest
 
   bump_version:
     name: Bump Version

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -162,13 +162,8 @@ jobs:
           flytectl demo start
           flytectl config init
       - name: Register examples
-        uses: unionai/flyte-register-action@v0.0.2
-        with:
-          flytesnacks: false
-          proto: ./download-artifact/**/*
-          project: flytesnacks
-          version: "latest"
-          domain: development
+        run: |
+          flytectl register files ./download-artifact/**/*.tar.gz --archive -p flytesnacks -d development --version latest
 
   bump_version:
     name: Bump Version


### PR DESCRIPTION
- Use flytectl directly in CI instead of `unionai/flyte-register-action` due to this [error](https://github.com/flyteorg/flytesnacks/actions/runs/9456070653/job/26049429152).
- Not sterilize the openai batch example at the moment since that cannot be registered for some reason.

<img width="1207" alt="Screenshot 2024-06-10 at 8 20 14 PM" src="https://github.com/flyteorg/flytesnacks/assets/37936015/84cf5c04-6172-4d4f-bb9a-e5e1a89b80e8">
