### PR TITLE
Remove pin on flytekit in the basics image

### DIFF
--- a/examples/basics/Dockerfile
+++ b/examples/basics/Dockerfile
@@ -17,7 +17,7 @@ ENV VENV /opt/venv
 RUN python3 -m venv ${VENV}
 ENV PATH="${VENV}/bin:$PATH"
 
-RUN pip install flytekit==1.10.0 flytekitplugins-envd
+RUN pip install flytekit flytekitplugins-envd
 
 # Copy the actual code
 COPY . /root

--- a/examples/house_price_prediction/requirements.in
+++ b/examples/house_price_prediction/requirements.in
@@ -2,7 +2,7 @@ flytekit>=0.32.3
 wheel
 matplotlib
 flytekitplugins-deck-standard
-xgboost
+xgboost<2.1.0
 joblib
 scikit-learn
 tabulate

--- a/examples/pima_diabetes/requirements.in
+++ b/examples/pima_diabetes/requirements.in
@@ -2,7 +2,7 @@ flytekit>=0.32.3
 wheel
 matplotlib
 flytekitplugins-deck-standard
-xgboost
+xgboost<2.1.0
 joblib
 scikit-learn
 tabulate


### PR DESCRIPTION
We're seeing an incompatibility between pandas and numpy which is causing older versions of flytekit to barf when loading `FlyteSchema` code (which used to depend explicitly on pandas).