### PR TITLE
Set python version to 3.9 in spark examples

### DIFF
--- a/examples/k8s_spark_plugin/k8s_spark_plugin/dataframe_passing.py
+++ b/examples/k8s_spark_plugin/k8s_spark_plugin/dataframe_passing.py
@@ -19,7 +19,7 @@ from typing_extensions import Annotated
 # %% [markdown]
 # Create an `ImageSpec` to automate the retrieval of a prebuilt Spark image.
 # %%
-custom_image = ImageSpec(registry="ghcr.io/flyteorg", packages=["flytekitplugins-spark"])
+custom_image = ImageSpec(python_version="3.9", registry="ghcr.io/flyteorg", packages=["flytekitplugins-spark"])
 
 # %% [markdown]
 # :::{important}

--- a/examples/k8s_spark_plugin/k8s_spark_plugin/pyspark_pi.py
+++ b/examples/k8s_spark_plugin/k8s_spark_plugin/pyspark_pi.py
@@ -16,7 +16,7 @@ from flytekitplugins.spark import Spark
 # %% [markdown]
 # Create an `ImageSpec` to automate the retrieval of a prebuilt Spark image.
 # %%
-custom_image = ImageSpec(registry="ghcr.io/flyteorg", packages=["flytekitplugins-spark"])
+custom_image = ImageSpec(python_version="3.9", registry="ghcr.io/flyteorg", packages=["flytekitplugins-spark"])
 
 
 # %% [markdown]


### PR DESCRIPTION
Otherwise the versions in the worker and the driver don't match and we see this error in the logs:
```
RuntimeError: Python in worker has different version 3.9 than that in driver 3.10, PySpark cannot run with different minor versions. Please check environment variables PYSPARK_PYTHON and PYSPARK_DRIVER_PYTHON are correctly set.
```