### PR TITLE
Add fake DocSearch API key to get monodocs build to succeed

### DIFF
--- a/.github/workflows/monodocs_build.yml
+++ b/.github/workflows/monodocs_build.yml
@@ -65,6 +65,7 @@ jobs:
         shell: bash -el {0}
         env:
           FLYTESNACKS_LOCAL_PATH: ${{ github.workspace }}/flytesnacks
+          DOCSEARCH_API_KEY: fake_docsearch_api_key  # must be set to get doc build to succeed
         run: |
           conda activate monodocs-env
           make -C docs html SPHINXOPTS="-W"


### PR DESCRIPTION
Adds a fake Algolia DocSearch API key to the build environment so the monodocs build will succeed. (DocSearch will not work in locally built docs.)