### PR TITLE
DOC-664 update flytekit docs links to point to flytekit repo

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -171,7 +171,7 @@ The {ref}`community <community>` would love to help you build new SDKs. Currentl
 :header-rows: 0
 :widths: 20 30
 
-* - {ref}`flytekit <https://docs.flyte.org/en/latest/api/flytekit/docs_index.html>`
+* - [flytekit](https://docs.flyte.org/en/latest/api/flytekit/docs_index.html)
   - The Python SDK for Flyte.
 * - [flytekit-java](https://github.com/spotify/flytekit-java)
   - The Java/Scala SDK for Flyte.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -171,7 +171,7 @@ The {ref}`community <community>` would love to help you build new SDKs. Currentl
 :header-rows: 0
 :widths: 20 30
 
-* - [flytekit](https://flytekit.readthedocs.io)
+* - {ref}`flytekit <https://docs.flyte.org/en/latest/api/flytekit/docs_index.html>`
   - The Python SDK for Flyte.
 * - [flytekit-java](https://github.com/spotify/flytekit-java)
   - The Java/Scala SDK for Flyte.
@@ -259,7 +259,7 @@ Hive </auto_examples/hive_plugin/index>
 :hidden:
 :caption: SDKs for writing tasks and workflows
 
-flytekit <https://flytekit.readthedocs.io/>
+flytekit <https://docs.flyte.org/en/latest/api/flytekit/docs_index.html>
 flytekit-java <https://github.com/spotify/flytekit-java>
 
 ```

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -171,9 +171,9 @@ The {ref}`community <community>` would love to help you build new SDKs. Currentl
 :header-rows: 0
 :widths: 20 30
 
-* - [flytekit](https://docs.flyte.org/en/latest/api/flytekit/docs_index.html)
+* - [flytekit](https://github.com/flyteorg/flytekit)
   - The Python SDK for Flyte.
-* - [flytekit-java](https://github.com/spotify/flytekit-java)
+* - [flytekit-java](https://github.com/flyteorg/flytekit-java)
   - The Java/Scala SDK for Flyte.
 ```
 
@@ -259,8 +259,8 @@ Hive </auto_examples/hive_plugin/index>
 :hidden:
 :caption: SDKs for writing tasks and workflows
 
-flytekit <https://docs.flyte.org/en/latest/api/flytekit/docs_index.html>
-flytekit-java <https://github.com/spotify/flytekit-java>
+flytekit <https://github.com/flyteorg/flytekit>
+flytekit-java <https://github.com/flyteorg/flytekit-java>
 
 ```
 


### PR DESCRIPTION
EDIT: Originally I updated the flytekit docs link, but given that the flytekit-java SDK link points to the fytekit-java repo, I changed the link to point to the flytekit repo instead. I also changed the spotify flytekit-java repo link to the flyteorg one, since it looks like that's where it's redirecting anyway.