### PR TITLE
[DOCS] Troubleshooting Steps for MPI Operator

### DIFF
--- a/examples/kfmpi_plugin/README.md
+++ b/examples/kfmpi_plugin/README.md
@@ -55,3 +55,37 @@ pyflyte run --remote \
 ```{auto-examples-toc}
 mpi_mnist
 ```
+
+## MPI Plugin Troubleshooting Guide
+
+This section covers common issues encountered during the setup of the MPI operator for distributed training jobs on Flyte.
+
+**Worker Pods Failing to Start (Insufficient Resources)**
+
+MPI worker pods may fail to start or exhibit scheduling issues, leading to job timeouts or failures. This often occurs due to resource constraints (CPU, memory, or GPU) in the cluster.
+
+1. Adjust Resource Requests:
+Ensure that each worker pod has sufficient resources. You can adjust the resource requests in your task definition:
+
+```
+    requests=Resources(cpu="<your_cpu_request>", mem="<your_mem_request>")
+```
+
+Modify the CPU and memory values according to your cluster's available resources. This helps prevent pod scheduling failures caused by resource constraints.
+
+2. Check Pod Logs for Errors:
+If the worker pods still fail to start, check the logs for any related errors:
+
+```
+    kubectl logs <pod-name> -n <namespace>
+```
+
+Look for resource allocation or worker communication errors.
+
+**Workflow Registration Method Errors (Timeouts or Deadlocks)**
+
+If your MPI workflow hangs or times out, it may be caused by an incorrect workflow registration method.
+
+1. Verify Registration Method:
+    When using a custom image, refer to the Flyte documentation on [Registering workflows](https://docs.flyte.org/en/latest/user_guide/flyte_fundamentals/registering_workflows.html#registration-patterns) to ensure you're following the correct registration method.
+


### PR DESCRIPTION
References Issue- https://github.com/flyteorg/flyte/issues/4464
Reference PR- https://github.com/flyteorg/flyte/pull/5857

This PR addresses the troubleshooting steps for the MPI operator as suggested in the feedback in [[Reference PR](https://github.com/flyteorg/flyte/pull/5857)]. I shifted the MPI common issues and troubleshooting steps for them to [MPI Guide itself](https://github.com/flyteorg/flytesnacks/blob/master/examples/kfmpi_plugin/README.md). 

This is a documentation update based on [[Issue in flyteorg/flyte ](https://github.com/flyteorg/flyte/issues/4464)] and [[Flyte Slack's conversation](https://discuss.flyte.org/t/13593667/hi-community-i-m-getting-an-unknown-status-on-every-workflow)] about MPI operator installation issues.

The suggestions to move the troubleshooting content came from the review of my previous PR in the flyteorg/flyte repository, which is linked here: [[PR MPI Operator](https://github.com/flyteorg/flyte/pull/5857)].

Why are the changes needed?
These changes provide important troubleshooting steps for users setting up the MPI operator for distributed training jobs on Flyte. The steps cover common issues like insufficient resource allocation for worker pods and clarify the correct workflow registration method, especially when using custom images. This will help users avoid common pitfalls and streamline the MPI operator setup process.

What changes were proposed in this pull request?
This pull request adds troubleshooting steps to the MPI operator installation documentation. Specifically, the following issues are addressed:

•	Insufficient Resources for Worker Pods: Steps to ensure sufficient CPU and memory requests are set.
•	Workflow Registration Method Errors: Clarification on using the correct registration method when working with custom images, with a link to the relevant Flyte documentation.

Check all the applicable boxes
 I updated the documentation accordingly.
 All new and existing tests passed.
 All commits are signed-off.