### PR TITLE
Broken PO tests corrected

### DIFF
--- a/examples/data_types_and_io/data_types_and_io/file.py
+++ b/examples/data_types_and_io/data_types_and_io/file.py
@@ -72,12 +72,12 @@ def normalize_csv_file(
 if __name__ == "__main__":
     default_files = [
         (
-            "https://people.sc.fsu.edu/~jburkardt/data/csv/biostats.csv",
+            "https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/test_data/biostats.csv",
             ["Name", "Sex", "Age", "Heights (in)", "Weight (lbs)"],
             ["Age"],
         ),
         (
-            "https://people.sc.fsu.edu/~jburkardt/data/csv/faithful.csv",
+            "https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/test_data/faithful.csv",
             ["Index", "Eruption length (mins)", "Eruption wait (mins)"],
             ["Eruption length (mins)"],
         ),

--- a/examples/data_types_and_io/data_types_and_io/folder.py
+++ b/examples/data_types_and_io/data_types_and_io/folder.py
@@ -93,8 +93,8 @@ def download_and_normalize_csv_files(
 # Run the workflow locally
 if __name__ == "__main__":
     csv_urls = [
-        "https://people.sc.fsu.edu/~jburkardt/data/csv/biostats.csv",
-        "https://people.sc.fsu.edu/~jburkardt/data/csv/faithful.csv",
+        "https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/test_data/biostats.csv",
+        "https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/test_data/faithful.csv",
     ]
     columns_metadata = [
         ["Name", "Sex", "Age", "Heights (in)", "Weight (lbs)"],


### PR DESCRIPTION
## Tracking issue
Closes [#4764](https://github.com/flyteorg/flyte/issues/4764)
Referecen Merged [PR](https://github.com/flyteorg/flytesnacks/pull/1764)

## Why are the changes needed?

Since Tests were broken because of relying on external sources for test data, but once my earlier [PR](https://github.com/flyteorg/flytesnacks/pull/1764), got merged, in which I hosted testing datasets locally, I used their raw github user link to replace external source links. Which increases robustness of these tests. @davidmirror-ops 

## What changes were proposed in this pull request?

Replaced external testing datasets link with internal raw github user links.

## How was this patch tested?

All tests using new links works fine, and gives expected output

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X ] All commits are signed-off.
