### PR TITLE
Example using ImageSpec in Raw container

### DIFF
--- a/examples/customizing_dependencies/customizing_dependencies/calculate-ellipse-area-new.py
+++ b/examples/customizing_dependencies/customizing_dependencies/calculate-ellipse-area-new.py
@@ -1,0 +1,29 @@
+import math
+import sys
+
+
+def write_output(output_dir, output_file, v):
+    with open(f"{output_dir}/{output_file}", "w") as f:
+        f.write(str(v))
+
+
+def calculate_area(a, b):
+    return math.pi * a * b
+
+
+def main(a, b, output_dir):
+    a = float(a)
+    b = float(b)
+
+    area = calculate_area(a, b)
+
+    write_output(output_dir, "area", area)
+    write_output(output_dir, "metadata", "[from python rawcontainer]")
+
+
+if __name__ == "__main__":
+    a = sys.argv[1]
+    b = sys.argv[2]
+    output_dir = sys.argv[3]
+
+    main(a, b, output_dir)

--- a/examples/customizing_dependencies/customizing_dependencies/raw_container.py
+++ b/examples/customizing_dependencies/customizing_dependencies/raw_container.py
@@ -1,6 +1,6 @@
 import logging
 
-from flytekit import ContainerTask, kwtypes, task, workflow
+from flytekit import ContainerTask, kwtypes, task, workflow, ImageSpec
 from flytekit.core.base_task import TaskMetadata
 
 logger = logging.getLogger(__file__)
@@ -35,7 +35,12 @@ calculate_ellipse_area_python = ContainerTask(
     output_data_dir="/var/outputs",
     inputs=kwtypes(a=float, b=float),
     outputs=kwtypes(area=float, metadata=str),
-    image="ghcr.io/flyteorg/rawcontainers-python:v2",
+    image=ImageSpec(
+        base_image="ghcr.io/flyteorg/rawcontainers-python:v2",
+        registry="localhost:30000",
+        builder="default",
+        copy=["calculate-ellipse-area.py"],
+    ),
     command=[
         "python",
         "calculate-ellipse-area.py",

--- a/examples/customizing_dependencies/customizing_dependencies/raw_container.py
+++ b/examples/customizing_dependencies/customizing_dependencies/raw_container.py
@@ -29,6 +29,7 @@ calculate_ellipse_area_shell = ContainerTask(
     metadata=TaskMetadata(cache=True, cache_version="1.0"),
 )
 
+# use `ImageSpec` to copy files or directories into container `/root`
 calculate_ellipse_area_python = ContainerTask(
     name="ellipse-area-metadata-python",
     input_data_dir="/var/inputs",

--- a/examples/customizing_dependencies/customizing_dependencies/raw_container.py
+++ b/examples/customizing_dependencies/customizing_dependencies/raw_container.py
@@ -40,11 +40,11 @@ calculate_ellipse_area_python = ContainerTask(
         base_image="ghcr.io/flyteorg/rawcontainers-python:v2",
         registry="localhost:30000",
         builder="default",
-        copy=["calculate-ellipse-area.py"],
+        copy=["calculate-ellipse-area-new.py"],
     ),
     command=[
         "python",
-        "calculate-ellipse-area.py",
+        "calculate-ellipse-area-new.py",
         "{{.inputs.a}}",
         "{{.inputs.b}}",
         "/var/outputs",

--- a/examples/customizing_dependencies/customizing_dependencies/raw_container.py
+++ b/examples/customizing_dependencies/customizing_dependencies/raw_container.py
@@ -1,6 +1,6 @@
 import logging
 
-from flytekit import ContainerTask, kwtypes, task, workflow, ImageSpec
+from flytekit import ContainerTask, ImageSpec, kwtypes, task, workflow
 from flytekit.core.base_task import TaskMetadata
 
 logger = logging.getLogger(__file__)


### PR DESCRIPTION
The raw container example ([link](https://docs.flyte.org/en/latest/user_guide/customizing_dependencies/raw_containers.html#raw-container)) does not show how to run the file that's not originally in the image. This PR add the example of using ImageSpec as the ContainerTask image to enable copying files to the container `/root`.

The following screenshots show that the code can be execute successfully.

![image](https://github.com/user-attachments/assets/a43fab2c-a5e4-4259-a0c5-7981681e1301)

![image](https://github.com/user-attachments/assets/5b081180-136c-4826-b67f-a661965628e0)


