### PR TITLE
Rename container_image to image for improved UX

### DIFF
--- a/examples/customizing_dependencies/customizing_dependencies/multi_images.py
+++ b/examples/customizing_dependencies/customizing_dependencies/multi_images.py
@@ -2,7 +2,7 @@ import numpy as np
 from flytekit import task, workflow
 
 
-@task(container_image="{{.image.mindmeld.fqn}}:{{.image.mindmeld.version}}")
+@task(image="{{.image.mindmeld.fqn}}:{{.image.mindmeld.version}}")
 def get_data() -> np.ndarray:
     # here we're importing scikit learn within the Flyte task
     from sklearn import datasets
@@ -12,7 +12,7 @@ def get_data() -> np.ndarray:
     return X
 
 
-@task(container_image="{{.image.borebuster.fqn}}:{{.image.borebuster.version}}")
+@task(image="{{.image.borebuster.fqn}}:{{.image.borebuster.version}}")
 def normalize(X: np.ndarray) -> np.ndarray:
     return (X - X.mean(axis=0)) / X.std(axis=0)
 


### PR DESCRIPTION
To enhance the user experience, the concept of `container` should be abstracted from flytekit users.

Hence, we propose to rename `container_image` of `flytekit.task()` decorator in the example code to `image`.

## Related PRs
* https://github.com/flyteorg/flytekit/pull/3094
* https://github.com/flyteorg/flyte/pull/6211

## Docs link
* https://flyte--6211.org.readthedocs.build/en/6211/user_guide/customizing_dependencies/multiple_images_in_a_workflow.html#id1