### PR TITLE
Doc: Provide example of launchplan chaining

### DIFF
--- a/examples/advanced_composition/advanced_composition/chain_entities.py
+++ b/examples/advanced_composition/advanced_composition/chain_entities.py
@@ -1,4 +1,4 @@
-from flytekit import task, workflow, LaunchPlan
+from flytekit import LaunchPlan, task, workflow
 
 
 @task
@@ -48,7 +48,9 @@ def chain_workflows_wf():
 
     sub_wf0 >> sub_wf1
 
+
 # Chaining launchplans
+
 
 @workflow
 def chain_launchplans_wf():

--- a/examples/advanced_composition/advanced_composition/chain_entities.py
+++ b/examples/advanced_composition/advanced_composition/chain_entities.py
@@ -1,4 +1,4 @@
-from flytekit import task, workflow
+from flytekit import task, workflow, LaunchPlan
 
 
 @task
@@ -47,3 +47,12 @@ def chain_workflows_wf():
     sub_wf0 = sub_workflow_0()
 
     sub_wf0 >> sub_wf1
+
+# Chaining launchplans
+
+@workflow
+def chain_launchplans_wf():
+    lp1 = LaunchPlan.get_or_create(sub_workflow_1, "lp1")()
+    lp0 = LaunchPlan.get_or_create(sub_workflow_0, "lp0")()
+
+    lp0 >> lp1


### PR DESCRIPTION
We provide an example [how to chain tasks and sub workflows with the `>>` operator](https://docs.flyte.org/en/latest/user_guide/advanced_composition/chaining_flyte_entities.html). I was recently asked by a user whether this works for launchplans as well as we don't provide an example for this case.
As this does in fact work, I'm adding an example in this PR.