### PR TITLE
add deprecated warning for pod example

### DIFF
--- a/examples/k8s_pod_plugin/k8s_pod_plugin/pod.py
+++ b/examples/k8s_pod_plugin/k8s_pod_plugin/pod.py
@@ -1,6 +1,14 @@
 # %% [markdown]
 # # Pod Example
 #
+# :::{Warning}
+# This plugin is no longer needed and is here only for backwards compatibility.
+# No new versions will be published after v1.13.x Please use the `pod_template`
+# and `pod_template_name` arguments to `@task` as described in the
+# {ref}`Kubernetes task pod configuration guide
+# <deployment-configuration-general>` instead.
+# :::
+#
 # Pod configuration for a Flyte task allows you to run multiple containers within a single task.
 # They provide access to a fully customizable [Kubernetes pod spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core),
 # which can be used to modify the runtime of the task execution.


### PR DESCRIPTION
## Related issue

https://github.com/flyteorg/flyte/issues/6347

## Description

Add warning and the link to the new PodTemplate page